### PR TITLE
Add shared release workflow from reissue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Release gem to RubyGems.org
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
+    with:
+      git_user_email: 'gems@sofwarellc.com'
+      git_user_name: 'SOFware'

--- a/README.md
+++ b/README.md
@@ -119,12 +119,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 
 This project is managed with [Reissue](https://github.com/SOFware/reissue).
 
-To release a new version, make your changes and be sure to update the CHANGELOG.md.
-
-To release a new version:
-
-1. `bundle exec rake build:checksum`
-2. `bundle exec rake release`
+Releases are automated via the [shared release workflow](https://github.com/SOFware/reissue/blob/main/.github/workflows/SHARED_WORKFLOW_README.md). Trigger a release by running the "Release gem to RubyGems.org" workflow from the Actions tab.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,5 +17,6 @@ require "reissue/gem"
 
 Reissue::Task.create :reissue do |task|
   task.version_file = "lib/gov_codes/version.rb"
-  task.fragment = :git # Enable git trailer extraction for changelog
+  task.fragment = :git
+  task.push_finalize = :branch
 end


### PR DESCRIPTION
## Summary
- Adds shared release workflow from reissue for trusted publishing to RubyGems.org

## Business Justification
Standardizes gem release process across SOFware repos using the shared reissue workflow, enabling automated trusted publishing to RubyGems.org via workflow_dispatch.

## Technical Details
Adds `.github/workflows/release.yml` that calls `SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main`