### PR TITLE
Bump required_ruby_version to >= 3.3

### DIFF
--- a/gov_codes.gemspec
+++ b/gov_codes.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Handle codes used by the US government."
   spec.description = "Process and understand codes used by the US government."
   spec.homepage = "https://github.com/SOFware/gov_codes"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/SOFware/gov_codes"


### PR DESCRIPTION
## Summary
- Bump `required_ruby_version` in the gemspec to `>= 3.3.0`

## Business Justification
Ruby 3.2 reached end-of-life on 2025-03-31, and earlier 3.x lines have been EOL longer. Advertising support for those versions in the gemspec misleads downstream consumers and lets them install us on Ruby they shouldn't be running. 3.3 is the oldest non-EOL line, so this aligns the gemspec floor with what we actually test against in CI.

## Technical Details
Metadata-only change. CI already runs against 3.3+, so no code changes are required.
