### PR TITLE
Require Ruby 3.2 for Data.define

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.302.0
+        uses: ruby/setup-ruby@v1.318.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/gov_codes.gemspec
+++ b/gov_codes.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Handle codes used by the US government."
   spec.description = "Process and understand codes used by the US government."
   spec.homepage = "https://github.com/SOFware/gov_codes"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/SOFware/gov_codes"


### PR DESCRIPTION
## Summary

- `Data.define` needs Ruby 3.2.0+; the gemspec said `>= 3.1.0` and the gem never actually loaded on 3.1.
- `ruby/setup-ruby@v1.302.0`'s bundled version manifest predates Ruby 4.0.5's ubuntu-24.04 build, breaking CI on main and every PR. Bumped to v1.318.0.

Not related to #44 (EOL-policy bump to 3.3) — these are the actual constraints.