### PR TITLE
Resolve as_of to today by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@ code = GovCodes::AFSC.find("1A172A")
 code.shredout_name      # => "C-5 Flight Engineer"
 
 # Enlisted lookups are versioned by DAFECD release (published each 30 Apr and
-# 31 Oct). `find`/`search` default to the latest shipped release; pass `as_of:`
-# (a Date or "YYYY-MM-DD" string) to resolve the release in effect on that date.
+# 31 Oct). `find`/`search` default to today's date; pass `as_of:` (a Date or
+# "YYYY-MM-DD" string) to resolve the release in effect on a different date. A
+# release only takes effect on its own effective_date, even if it's the most
+# recently added one (e.g. one you pre-load ahead of its official date).
 code = GovCodes::AFSC.find("1A172Y", as_of: "2025-11-01")
 code.effective_date     # => #<Date: 2025-10-31>
 # A date before the earliest shipped release has no data and returns nil.
 GovCodes::AFSC.find("1A172Y", as_of: "2000-01-01") # => nil
 
 # Find an officer AFSC code. Officer lookups are versioned by DAFOCD release
-# (like enlisted); `find`/`search` default to the latest shipped release and
-# accept the same `as_of:`.
+# (like enlisted); `find`/`search` default to today's date and accept the
+# same `as_of:`.
 code = GovCodes::AFSC.find("11MX")
 puts code.name # => "Mobility Pilot"
 puts code.career_group # => "11"
@@ -179,13 +181,15 @@ Pair it with a matching `releases/dafecd/2026-04-30/enlisted.yml` index, and
 
 AFSC data is extracted from the official **Department of the Air Force classification directories** — the DAFECD (enlisted) and DAFOCD (officer) — not third-party sources. Extraction is deterministic, and every code is verified to appear verbatim in the source directory: no predicted or hallucinated codes.
 
-The data is **versioned by each directory's effective date** (the directories are republished roughly semi-annually, on 30 April and 31 October). Look a code up as it stood for a given release, or take the latest:
+The data is **versioned by each directory's effective date** (the directories are republished roughly semi-annually, on 30 April and 31 October). Look a code up as it stands today, or as it stood for a given release:
 
 ```ruby
-GovCodes::AFSC.find("1A172Y")                        # latest shipped release
+GovCodes::AFSC.find("1A172Y")                        # the release in effect today
 GovCodes::AFSC.find("1A172Y", as_of: "2025-11-01")   # the release in effect on that date
 GovCodes::AFSC.find("1A172Y").effective_date         # => the release the result came from
 ```
+
+`as_of: nil` (the default) is today's date, not "whatever's newest" — a release only takes effect on its own effective_date. This only differs from "the latest shipped release" if a release dated in the future has been added to the load path (see "Extending with Custom AFSC Codes" above); until that date arrives, lookups keep resolving against the current release.
 
 **Currently shipped:** enlisted AFSCs from the DAFECD and officer AFSCs from the DAFOCD, both effective 31 October 2025. Reporting/special-duty identifiers (RI/SDI), SEIs, prefixes, and Space Force codes are planned.
 

--- a/lib/gov_codes/afsc.rb
+++ b/lib/gov_codes/afsc.rb
@@ -5,9 +5,10 @@ require_relative "afsc/ri"
 module GovCodes
   module AFSC
     # Resolve a code as of the classification-directory release in effect on
-    # +as_of+ (default: the latest shipped release). +as_of+ applies to the
-    # versioned enlisted (DAFECD) and officer (DAFOCD) lookups, each resolved
-    # against its own publication; RI is unversioned.
+    # +as_of+ (default: today). +as_of+ applies to the versioned enlisted
+    # (DAFECD) and officer (DAFOCD) lookups, each resolved against its own
+    # publication; RI is unversioned and accepts +as_of+ only for interface
+    # parity (it is ignored).
     def self.find(code, as_of: nil)
       AFSC::Enlisted.find(code, as_of: as_of) ||
         AFSC::Officer.find(code, as_of: as_of) ||
@@ -15,10 +16,10 @@ module GovCodes
     end
 
     # Resolve a code by its acronym (case-insensitive) as of the release in
-    # effect on +as_of+ (default: the latest shipped release). Searches the
-    # enlisted tier (source-verified acronyms + that release's overlay), then the
-    # officer tier (specialty and shredout acronyms + that release's overlay),
-    # then the unversioned RI overlay. Returns a single Code or nil.
+    # effect on +as_of+ (default: today). Searches the enlisted tier
+    # (source-verified acronyms + that release's overlay), then the officer
+    # tier (specialty and shredout acronyms + that release's overlay), then the
+    # unversioned RI overlay. Returns a single Code or nil.
     #
     # Acronyms are expected to be unique. If two codes carry the same acronym,
     # the first match wins in a defined order: enlisted before officer before RI,
@@ -26,7 +27,7 @@ module GovCodes
     def self.find_by_acronym(acronym, as_of: nil)
       AFSC::Enlisted.find_by_acronym(acronym, as_of: as_of) ||
         AFSC::Officer.find_by_acronym(acronym, as_of: as_of) ||
-        AFSC::RI.find_by_acronym(acronym)
+        AFSC::RI.find_by_acronym(acronym, as_of: as_of)
     end
 
     def self.search(prefix, as_of: nil)

--- a/lib/gov_codes/afsc/enlisted.rb
+++ b/lib/gov_codes/afsc/enlisted.rb
@@ -109,9 +109,9 @@ module GovCodes
       )
 
       # Resolve an enlisted AFSC against the DAFECD release in effect on +as_of+
-      # (default: the latest shipped release). Returns nil when the code does not
-      # parse, when the specialty is absent from the resolved release, or when
-      # +as_of+ precedes the earliest shipped release.
+      # (default: today). Returns nil when the code does not parse, when the
+      # specialty is absent from the resolved release, or when +as_of+ precedes
+      # the earliest shipped release (or no release has taken effect yet).
       def self.find(code, as_of: nil)
         code = code.to_s
         # Key the memo on the RESOLVED release date so equivalent as_of values

--- a/lib/gov_codes/afsc/officer.rb
+++ b/lib/gov_codes/afsc/officer.rb
@@ -6,7 +6,7 @@ module GovCodes
     # Officer AFSCs resolved against the versioned DAFOCD release index. Mirrors
     # Enlisted: +find(code, as_of:)+ resolves the X-form specialty (e.g. :11BX)
     # or a literal bare code (e.g. :10C0) in the release in effect on +as_of+,
-    # defaulting to the latest shipped release.
+    # defaulting to today.
     module Officer
       class Parser
         def initialize(code)
@@ -77,9 +77,10 @@ module GovCodes
       )
 
       # Resolve an officer AFSC against the DAFOCD release in effect on +as_of+
-      # (default: the latest shipped release). Returns nil when the code does not
-      # parse, when neither the X-form specialty nor a literal bare code resolves
-      # in the release, or when +as_of+ precedes the earliest shipped release.
+      # (default: today). Returns nil when the code does not parse, when neither
+      # the X-form specialty nor a literal bare code resolves in the release, or
+      # when +as_of+ precedes the earliest shipped release (or no release has
+      # taken effect yet).
       def self.find(code, as_of: nil)
         code = code.to_s
         # Key the memo on the RESOLVED release date so equivalent as_of values

--- a/lib/gov_codes/afsc/releases.rb
+++ b/lib/gov_codes/afsc/releases.rb
@@ -18,8 +18,12 @@ module GovCodes
     #
     # Resolution: releases are sorted ascending by effective_date. A given
     # `as_of` resolves to the release with the greatest effective_date <= as_of;
-    # `as_of: nil` resolves to the latest release. A date before the earliest
-    # shipped release resolves to no release (an empty index / nil date).
+    # `as_of: nil` resolves it as of today. A release only takes effect on its
+    # own effective_date -- a release dated in the future (e.g. one a consumer
+    # pre-loads ahead of its official date, see DEC-004 below) is not resolved
+    # until that date arrives, even though it is the most recently added one. A
+    # date before the earliest shipped release resolves to no release (an empty
+    # index / nil date).
     #
     # Extensibility (DEC-004): both tiers merge across the load path (gem lib dir
     # first, then the load path). The manifest's per-publication release list is
@@ -90,21 +94,26 @@ module GovCodes
           ([gem_lib_dir] + Array(lookup)).uniq
         end
 
-        # Resolve, merge, and cache the release index for +publication+. The
-        # cache key includes the publication and index filename so enlisted and
-        # officer indexes never collide.
+        # Resolve, merge, and cache the release index for +publication+. Always
+        # resolves the release first (cheap: the manifest itself is cached) and
+        # keys the expensive part -- loading and merging the index file -- on
+        # the RESOLVED release's date, not the raw +as_of+. With `as_of: nil`
+        # meaning "today," keying on the raw input would freeze the cache to
+        # whichever release happened to be current at the first call and never
+        # notice a later release's effective_date arrive.
         def release_index(publication, index_file, as_of:, lookup:)
-          key = [publication, index_file, to_date(as_of), cache_key(lookup)]
-          index_cache[key] ||= load_release_index(publication, index_file, as_of: as_of, lookup: lookup)
+          release = resolve_release(publication, as_of: as_of, lookup: lookup)
+          return {} unless release
+
+          key = [publication, index_file, release[:date], cache_key(lookup)]
+          index_cache[key] ||= load_release_index(release, publication, index_file, lookup)
         end
 
         def resolve_release(publication, as_of:, lookup:)
           releases = release_list(lookup, publication)
           return nil if releases.empty?
 
-          target = to_date(as_of)
-          return releases.last if target.nil?
-
+          target = to_date(as_of) || Date.today
           releases.reverse.find { |r| r[:date] <= target }
         end
 
@@ -131,10 +140,7 @@ module GovCodes
           merged
         end
 
-        def load_release_index(publication, index_file, as_of:, lookup:)
-          release = resolve_release(publication, as_of: as_of, lookup: lookup)
-          return {} unless release
-
+        def load_release_index(release, publication, index_file, lookup)
           merged = {}
           parts = ["gov_codes", "afsc", "releases", publication, release[:dir], index_file]
           each_yaml(lookup, parts) { |data| merged.merge!(data) }

--- a/lib/gov_codes/afsc/ri.rb
+++ b/lib/gov_codes/afsc/ri.rb
@@ -142,8 +142,10 @@ module GovCodes
 
       # Resolve the RI code whose consumer-overlay acronym matches +acronym+
       # (case-insensitive), or nil. RI acronyms come only from the
-      # ri_acronyms.yml overlay (none are extracted from source).
-      def self.find_by_acronym(acronym)
+      # ri_acronyms.yml overlay (none are extracted from source). +as_of+ is
+      # accepted for interface parity with Enlisted/Officer and ignored: RI
+      # data is not versioned by release yet.
+      def self.find_by_acronym(acronym, as_of: nil)
         acronym = acronym.to_s.upcase
         return nil if acronym.empty?
 

--- a/test/gov_codes/afsc/enlisted_release_test.rb
+++ b/test/gov_codes/afsc/enlisted_release_test.rb
@@ -12,16 +12,17 @@ module GovCodes
     describe "Enlisted versioned lookup" do
       before do
         @temp_dir = Dir.mktmpdir
+        @release_date = Date.today
         afsc_dir = File.join(@temp_dir, "gov_codes", "afsc")
-        # A future release date so `as_of: nil` (latest) resolves to this
-        # synthetic release rather than the gem's shipped one (release lists are
-        # unioned across the load path).
-        release_dir = File.join(afsc_dir, "releases", "dafecd", "2099-06-30")
+        # Dated today so `as_of: nil` (today) resolves to this synthetic release
+        # rather than the gem's shipped one (release lists are unioned across
+        # the load path).
+        release_dir = File.join(afsc_dir, "releases", "dafecd", @release_date.iso8601)
         FileUtils.mkdir_p(release_dir)
 
         File.write(File.join(afsc_dir, "releases.yml"), <<~YAML)
           :dafecd:
-          - :effective_date: '2099-06-30'
+          - :effective_date: '#{@release_date.iso8601}'
             :version_label: test
             :source: synthetic.pdf
             :name: Synthetic Directory
@@ -62,7 +63,7 @@ module GovCodes
 
       it "carries the release effective_date on the resolved code" do
         code = Enlisted.find("1A172")
-        _(code.effective_date).must_equal Date.new(2099, 6, 30)
+        _(code.effective_date).must_equal @release_date
       end
 
       it "resolves a shredout name from the versioned index" do
@@ -77,9 +78,9 @@ module GovCodes
       end
 
       it "resolves the same code for an as_of within the release window" do
-        code = Enlisted.find("1A172", as_of: "2099-06-30")
+        code = Enlisted.find("1A172", as_of: @release_date.iso8601)
         _(code.specialty_name).must_equal "Mobility Force Aviator"
-        _(code.effective_date).must_equal Date.new(2099, 6, 30)
+        _(code.effective_date).must_equal @release_date
       end
 
       it "returns nil for a specialty absent from the release" do
@@ -97,7 +98,7 @@ module GovCodes
         it "carries the release effective_date on searched codes" do
           codes = Enlisted.search("1A1X2")
           _(codes).wont_be_empty
-          codes.each { |c| _(c.effective_date).must_equal Date.new(2099, 6, 30) }
+          codes.each { |c| _(c.effective_date).must_equal @release_date }
         end
 
         it "is case-insensitive" do

--- a/test/gov_codes/afsc/releases_test.rb
+++ b/test/gov_codes/afsc/releases_test.rb
@@ -124,7 +124,10 @@ module GovCodes
 
     # DEC-004: a consumer manifest must MERGE its releases into the shipped list
     # (union by effective_date), not replace it. Adding a release must not hide
-    # the gem's shipped 2025-10-31 release.
+    # the gem's shipped 2025-10-31 release. A release dated in the future must
+    # not take effect early just because it is the most recently added one --
+    # `as_of: nil` (today) keeps resolving the shipped release until the future
+    # release's own effective_date actually arrives.
     describe "Releases manifest merging" do
       before do
         @temp_dir = Dir.mktmpdir
@@ -167,28 +170,38 @@ module GovCodes
         _(index.dig(:"1A1X2", :name)).must_equal "Mobility Force Aviator"
       end
 
-      it "resolves the consumer-added release as the latest" do
+      it "does not resolve a future release before its effective_date arrives" do
         index = Releases.enlisted_index(as_of: nil, lookup: [@temp_dir])
-        _(index.key?(:"9Q9X9")).must_equal true
+        _(index.key?(:"9Q9X9")).must_equal false
+        _(index.key?(:"1A1X2")).must_equal true # still the shipped release
         _(Releases.effective_date_for(as_of: nil, lookup: [@temp_dir]))
+          .must_equal Date.new(2025, 10, 31)
+      end
+
+      it "resolves the future release once as_of reaches its effective_date" do
+        index = Releases.enlisted_index(as_of: "2099-12-31", lookup: [@temp_dir])
+        _(index.key?(:"9Q9X9")).must_equal true
+        _(Releases.effective_date_for(as_of: "2099-12-31", lookup: [@temp_dir]))
           .must_equal Date.new(2099, 12, 31)
       end
     end
 
     # The officer (DAFOCD) publication reuses the same resolve/merge/cache
     # machinery as enlisted (DAFECD) but reads officer.yml under releases/dafocd.
-    # A future release date keeps the resolved index free of the 130-entry
-    # shipped index so these assertions are self-contained.
+    # Dated today (rather than the shipped 2025-10-31) so `as_of: nil` resolves
+    # this synthetic release instead of the real 130-entry shipped index, keeping
+    # these assertions self-contained.
     describe "Releases officer index" do
       before do
         @temp_dir = Dir.mktmpdir
+        @release_date = Date.today
         base = File.join(@temp_dir, "gov_codes", "afsc")
-        release_dir = File.join(base, "releases", "dafocd", "2099-06-30")
+        release_dir = File.join(base, "releases", "dafocd", @release_date.iso8601)
         FileUtils.mkdir_p(release_dir)
 
         File.write(File.join(base, "releases.yml"), <<~YAML)
           :dafocd:
-          - :effective_date: '2099-06-30'
+          - :effective_date: '#{@release_date.iso8601}'
             :version_label: test
             :source: synthetic-officer.pdf
             :name: Synthetic Officer Directory
@@ -230,7 +243,7 @@ module GovCodes
       it "resolves the officer effective date via the officer publication" do
         _(Releases.effective_date_for(as_of: nil, lookup: [@temp_dir],
           publication: Releases::OFFICER_PUBLICATION))
-          .must_equal Date.new(2099, 6, 30)
+          .must_equal @release_date
       end
 
       it "resolves each publication's effective date independently" do
@@ -251,13 +264,14 @@ module GovCodes
     describe "Releases officer acronym overlay" do
       before do
         @temp_dir = Dir.mktmpdir
+        release_date = Date.today
         base = File.join(@temp_dir, "gov_codes", "afsc")
-        release_dir = File.join(base, "releases", "dafocd", "2099-06-30")
+        release_dir = File.join(base, "releases", "dafocd", release_date.iso8601)
         FileUtils.mkdir_p(release_dir)
 
         File.write(File.join(base, "releases.yml"), <<~YAML)
           :dafocd:
-          - :effective_date: '2099-06-30'
+          - :effective_date: '#{release_date.iso8601}'
             :version_label: test
             :source: synthetic-officer.pdf
             :name: Synthetic Officer Directory

--- a/test/gov_codes/afsc_versioned_test.rb
+++ b/test/gov_codes/afsc_versioned_test.rb
@@ -9,15 +9,16 @@ module GovCodes
   describe "AFSC versioned lookup" do
     before do
       @temp_dir = Dir.mktmpdir
+      @release_date = Date.today
       afsc_dir = File.join(@temp_dir, "gov_codes", "afsc")
-      # Future release date: `as_of: nil` (latest) resolves to this synthetic
-      # release, which the loader unions with the gem's shipped release.
-      release_dir = File.join(afsc_dir, "releases", "dafecd", "2099-06-30")
+      # Dated today: `as_of: nil` (today) resolves to this synthetic release,
+      # which the loader unions with the gem's shipped release.
+      release_dir = File.join(afsc_dir, "releases", "dafecd", @release_date.iso8601)
       FileUtils.mkdir_p(release_dir)
 
       File.write(File.join(afsc_dir, "releases.yml"), <<~YAML)
         :dafecd:
-        - :effective_date: '2099-06-30'
+        - :effective_date: '#{@release_date.iso8601}'
           :version_label: test
           :source: synthetic.pdf
           :name: Synthetic Directory
@@ -49,7 +50,7 @@ module GovCodes
       code = AFSC.find("1A172")
       _(code).must_be_instance_of AFSC::Enlisted::Code
       _(code.name).must_equal "Mobility Force Aviator"
-      _(code.effective_date).must_equal Date.new(2099, 6, 30)
+      _(code.effective_date).must_equal @release_date
     end
 
     it "returns nil when as_of precedes the earliest release" do
@@ -57,7 +58,7 @@ module GovCodes
     end
 
     it "threads as_of into search" do
-      codes = AFSC.search("1A1X2", as_of: "2099-06-30").map(&:specialty)
+      codes = AFSC.search("1A1X2", as_of: @release_date.iso8601).map(&:specialty)
       _(codes).must_include :"1A1X2"
     end
 


### PR DESCRIPTION
## Summary

- `as_of: nil` picked the newest release regardless of its own effective_date, so a release pre-loaded ahead of its official date (DEC-004) would take effect early. Default to today: resolve the latest release with effective_date <= today. Unchanged in the common case (no future-dated release present).
- Thread `as_of` through `RI.find_by_acronym` for interface parity with Enlisted/Officer (RI stays unversioned; the parameter is accepted and ignored).
- Fixed the release-index cache to key on the resolved release date rather than the raw `as_of`, so a long-running process notices a release boundary pass instead of freezing on whichever release was current at first call.