### PR TITLE
Fix DAFOCD officer ladder regex for six missed AFSCs

### DIFF
--- a/lib/gov_codes/afsc/releases/dafocd/2025-10-31/officer.yml
+++ b/lib/gov_codes/afsc/releases/dafocd/2025-10-31/officer.yml
@@ -849,6 +849,23 @@
     :G: AFRICOM
     :H: EUCOM
     :L: Generalist (applies only to billets)
+:17DX:
+  :name: Warfighter Communications
+  :career_field: :17
+  :changed_date: '2025-10-31'
+  :qual_levels:
+    1:
+      :code: 17D1
+      :title: Entry
+    3:
+      :code: 17D3
+      :title: Qualified
+    4:
+      :code: 17D4
+      :title: Staff
+  :shredouts:
+    :T: Technical Track
+    :W: Warfighter Communications
 :17SX:
   :name: Cyberspace Effects Operations
   :career_field: :17
@@ -1412,6 +1429,21 @@
       :code: 44A3
       :title: Qualified
   :shredouts: {}
+:44BX:
+  :name: Preventive Medicine Physician
+  :career_field: :44
+  :changed_date: '2025-04-30'
+  :qual_levels:
+    1:
+      :code: 44B1
+      :title: Entry
+    3:
+      :code: 44B3
+      :title: Qualified
+    4:
+      :code: 44B4
+      :title: Staff
+  :shredouts: {}
 :44DX:
   :name: Pathologist
   :career_field: :44
@@ -1717,6 +1749,21 @@
     4:
       :code: 44Z4
       :title: Staff
+  :shredouts: {}
+:45AX:
+  :name: Anesthesiologist
+  :career_field: :45
+  :changed_date: '2025-04-30'
+  :qual_levels:
+    1:
+      :code: 45A1
+      :title: Entry
+    3:
+      :code: 45A3
+      :title: Qualified
+    4:
+      :code: 45A4
+      :title: Staff
   :shredouts:
     :A: Cardiothoracic
     :B: Pain Management
@@ -1953,6 +2000,21 @@
       :code: 46Y4
       :title: Staff
   :shredouts: {}
+:47BX:
+  :name: Orthodontist
+  :career_field: :47
+  :changed_date: '2023-10-31'
+  :qual_levels:
+    1:
+      :code: 47B1
+      :title: Entry
+    3:
+      :code: 47B3
+      :title: Qualified
+    4:
+      :code: 47B4
+      :title: Staff
+  :shredouts: {}
 :47DX:
   :name: Oral and Maxillofacial Pathologist
   :career_field: :47
@@ -2035,6 +2097,21 @@
     4:
       :code: 47K4
       :title: Staff
+  :shredouts: {}
+:47PX:
+  :name: Prosthodontist
+  :career_field: :47
+  :changed_date: '2023-10-31'
+  :qual_levels:
+    1:
+      :code: 47P1
+      :title: Entry
+    3:
+      :code: 47P3
+      :title: Qualified
+    4:
+      :code: 47P4
+      :title: Staff
   :shredouts:
     :A: Maxillofacial Prosthetics
     :B: Area Dental Laboratory
@@ -2068,6 +2145,22 @@
       :title: Qualified
     4:
       :code: 48A4
+      :title: Staff
+  :shredouts:
+    :X: Space Medical Operations Experienced
+:48GX:
+  :name: General Medical Officer (GMO), Flight Surgeon
+  :career_field: :48
+  :changed_date: '2025-04-30'
+  :qual_levels:
+    1:
+      :code: 48G1
+      :title: Entry
+    3:
+      :code: 48G3
+      :title: Qualified
+    4:
+      :code: 48G4
       :title: Staff
   :shredouts:
     :X: Space Medical Operations Experienced

--- a/lib/gov_codes/dafecd/publication.rb
+++ b/lib/gov_codes/dafecd/publication.rb
@@ -63,9 +63,27 @@ module GovCodes
       # also still rejects the 5-char shred-code / long-sentence prose mentions.
       # An optional leading/trailing "AFSC" absorbs the same pdf-reader glue the
       # enlisted ladder handles (e.g. "11G4, StaffAFSC").
+      #
+      # The directory is INCONSISTENT about three things, all tolerated here:
+      #   * COMMA (group A): most cards print "AFSC 11B4, Staff", but several live
+      #     medical cards omit the comma and separate with a space ("AFSC 44B4
+      #     Staff", "AFSC 45A4* Staff"). Hence the separator is comma-or-space,
+      #     NOT a bare optional comma: requiring at least one of comma/whitespace
+      #     is what still rejects glued-shred prose such as "AFSC 42B3Z requires
+      #     successful completion of" and "AFSC 43E3Aand complete the education",
+      #     where an uppercase shred letter is glued to the code with no
+      #     separator before the lowercase prose. A bare ",?" would let those in.
+      #   * SHRED LETTER (group B): a few cards print the qualification code with
+      #     a glued shredout letter, e.g. "AFSC 17D4W*, Staff". The optional
+      #     "[A-Z]" absorbs it so it is NOT baked into the captured concrete code
+      #     (group 1 stays "17D4"); the letter is documented as a shredout via the
+      #     card's shredout table instead (see ShredoutParser).
+      #   * LEADING GLYPH: pdf-reader prepends a Private Use Area / bullet glyph
+      #     to some ladder lines (e.g. U+F0EA on the 17D card). The leading class
+      #     mirrors Patterns::DECORATIVE so the anchor tolerates it.
       DAFOCD_LADDER = %r{
-        ^\s*(?:AFSC\s+)?(\d\d[A-Z][1-4])\*?
-        ,\s*
+        ^[\s\u{E000}-\u{F8FF}★☆•●▪■⁃∙]*(?:AFSC\s+)?(\d\d[A-Z][1-4])[A-Z]?\*?
+        (?:,\s*|\s+)
         ([A-Z][A-Za-z/\ ]{0,44}?)
         (?:\s*AFSC)?
         \s*$

--- a/lib/gov_codes/dafecd/title_overrides/dafocd.yml
+++ b/lib/gov_codes/dafecd/title_overrides/dafocd.yml
@@ -43,6 +43,7 @@
 :16PX: Political-Military Affairs Strategist (PAS)
 :16RX: Planning and Programming
 :16ZX: Rated Foreign Area Officer (FAO)
+:17DX: Warfighter Communications
 :17SX: Cyberspace Effects Operations
 :17WX: Warfighter Communications & IT Systems
 :17YX: Cyber Effects & Warfare Operations
@@ -79,6 +80,7 @@
 :43PX: Pharmacist
 :43TX: Biomedical Laboratory
 :44AX: Chief of Medical Staff
+:44BX: Preventive Medicine Physician
 :44DX: Pathologist
 :44EX: Emergency Medicine Physician
 :44FX: Family Physician
@@ -96,6 +98,7 @@
 :44UX: Occupational Medicine Physician
 :44YX: Critical Care Medicine Physician
 :44ZX: Allergist and Immunologist
+:45AX: Anesthesiologist
 :45BX: Orthopaedic Surgeon
 :45EX: Ophthalmologist
 :45GX: Gynecologic Surgeon and Obstetrician
@@ -109,13 +112,16 @@
 :46PX: Mental Health Nurse
 :46SX: Operating Room Nurse
 :46YX: Advanced Practice Registered Nurse (APRN)
+:47BX: Orthodontist
 :47DX: Oral and Maxillofacial Pathologist
 :47EX: Endodontist
 :47GX: Dentist
 :47HX: Periodontist
 :47KX: Pediatric Dentist
+:47PX: Prosthodontist
 :47SX: Oral and Maxillofacial Surgeon
 :48AX: Aerospace Medicine Physician Specialist
+:48GX: General Medical Officer (GMO), Flight Surgeon
 :48OX: Aeromedical Physician
 :48RX: Residency Trained Flight Surgeon
 :48VX: Pilot-Physician

--- a/test/gov_codes/afsc/releases_test.rb
+++ b/test/gov_codes/afsc/releases_test.rb
@@ -189,7 +189,7 @@ module GovCodes
     # The officer (DAFOCD) publication reuses the same resolve/merge/cache
     # machinery as enlisted (DAFECD) but reads officer.yml under releases/dafocd.
     # Dated today (rather than the shipped 2025-10-31) so `as_of: nil` resolves
-    # this synthetic release instead of the real 130-entry shipped index, keeping
+    # this synthetic release instead of the real 136-entry shipped index, keeping
     # these assertions self-contained.
     describe "Releases officer index" do
       before do

--- a/test/gov_codes/dafecd/index_builder_test.rb
+++ b/test/gov_codes/dafecd/index_builder_test.rb
@@ -474,6 +474,53 @@ describe GovCodes::Dafecd::IndexBuilder do
       _(builder.unverified_acronyms).must_be_empty
     end
 
+    # Real 17D (Warfighter Communications): the ladder prints a glued shredout
+    # letter and a leading decorative glyph on every level, and the card's
+    # shredout table documents the same suffixes. The shred letter must NOT end
+    # up baked into the concrete code -- it flows through as a shredout instead.
+    let(:warfighter_text) {
+      pua = "\u{F0EA}"
+      <<~TXT
+        DAFOCD, 31 Oct 25
+        #{pua}AFSC 17D4W*, Staff
+        #{pua}AFSC 17D3W*, Qualified
+        #{pua}AFSC 17D1W*, Entry
+                                     WARFIGHTER COMMUNICATIONS
+                                     (Changed 31 Oct 25)
+
+        1. Specialty Summary. Operates cyberspace infrastructure.
+
+        4. *Specialty Shredouts:
+
+         Suffix        Portion of AFS to Which Related
+            T          Technical Track
+         W             Warfighter Communications
+      TXT
+    }
+
+    it "keys the glued-shred 17D card by its X-form family with clean codes" do
+      index = build(warfighter_text).build
+      _(index.keys).must_include :"17DX"
+      entry = index[:"17DX"]
+      _(entry[:qual_levels][4]).must_equal({code: "17D4", title: "Staff"})
+      _(entry[:qual_levels][1]).must_equal({code: "17D1", title: "Entry"})
+    end
+
+    it "flows the glued shred letter through as a shredout, not into the code" do
+      entry = build(warfighter_text).build[:"17DX"]
+      _(entry[:shredouts][:W]).must_equal "Warfighter Communications"
+      _(entry[:shredouts][:T]).must_equal "Technical Track"
+      # The concrete ladder codes never carry the W.
+      codes = entry[:qual_levels].values.map { |l| l[:code] }
+      _(codes.any? { |c| c.include?("W") }).must_equal false
+    end
+
+    it "keeps the verification gate clean for the 17D card" do
+      builder = build(warfighter_text)
+      builder.build
+      _(builder.unverified?).must_equal false
+    end
+
     # Bare single-code record (10C0, Operations Commander).
     let(:bare_text) {
       <<~TXT

--- a/test/gov_codes/dafecd/specialty_parser_test.rb
+++ b/test/gov_codes/dafecd/specialty_parser_test.rb
@@ -452,5 +452,90 @@ describe GovCodes::Dafecd::SpecialtyParser do
       result = parse(record)
       _(result[:qual_levels].keys.sort).must_equal [1, 4]
     end
+
+    # GAP A: several live medical cards (44B, 47B, 48G) omit the comma the older
+    # anchor required, separating the code from the title with only a space --
+    # e.g. "AFSC 44B4 Staff". A whitespace separator must be accepted too.
+    it "parses a no-comma officer ladder where a space separates code and title" do
+      record = <<~TXT
+        AFSC 44B4 Staff
+        AFSC 44B3 Qualified
+        AFSC 44B1 Entry
+                                      PREVENTIVE MEDICINE PHYSICIAN
+                                      (Changed 30Apr 25)
+
+        1. Specialty Summary. Practices preventive medicine.
+      TXT
+      result = parse(record)
+      _(result[:specialty]).must_equal :"44BX"
+      _(result[:qual_levels][4]).must_equal({code: "44B4", title: "Staff"})
+      _(result[:qual_levels][3]).must_equal({code: "44B3", title: "Qualified"})
+      _(result[:qual_levels][1]).must_equal({code: "44B1", title: "Entry"})
+      _(result[:name]).must_equal "Preventive Medicine Physician"
+    end
+
+    # GAP A + restriction star (45A, 47P): a no-comma ladder whose code carries a
+    # trailing "*" -- e.g. "AFSC 45A4* Staff".
+    it "parses a no-comma officer ladder that carries a restriction star" do
+      record = <<~TXT
+        AFSC 45A4* Staff
+        AFSC 45A3* Qualified
+        AFSC 45A1* Entry
+                                      ANESTHESIOLOGIST
+                                      (Changed 30Apr 25)
+
+        1. Specialty Summary. Administers anesthesia.
+      TXT
+      result = parse(record)
+      _(result[:specialty]).must_equal :"45AX"
+      _(result[:qual_levels][4]).must_equal({code: "45A4", title: "Staff"})
+      _(result[:qual_levels][3]).must_equal({code: "45A3", title: "Qualified"})
+      _(result[:qual_levels][1]).must_equal({code: "45A1", title: "Entry"})
+    end
+
+    # GAP B: the live 17D card prints its qualification codes with a glued
+    # shredout letter and a leading decorative glyph -- e.g.
+    # "<U+F0EA>AFSC 17D4W*, Staff". The anchor must tolerate the leading glyph
+    # and absorb the shred letter WITHOUT merging it into the concrete code.
+    it "parses a glued-shred-letter ladder with a leading decorative glyph (17D)" do
+      pua = "\u{F0EA}"
+      record = <<~TXT
+        #{pua}AFSC 17D4W*, Staff
+        #{pua}AFSC 17D3W*, Qualified
+        #{pua}AFSC 17D1W*, Entry
+                                      WARFIGHTER COMMUNICATIONS
+                                      (Changed 31 Oct 25)
+
+        1. Specialty Summary. Operates cyberspace infrastructure.
+      TXT
+      result = parse(record)
+      _(result[:specialty]).must_equal :"17DX"
+      # The concrete code stays four chars; the shred letter W is NOT merged in
+      # (it flows through as a shredout, keyed off the card's shredout table).
+      _(result[:qual_levels][4]).must_equal({code: "17D4", title: "Staff"})
+      _(result[:qual_levels][3]).must_equal({code: "17D3", title: "Qualified"})
+      _(result[:qual_levels][1]).must_equal({code: "17D1", title: "Entry"})
+    end
+
+    # GAP A regression guard: loosening the comma to an optional separator must
+    # NOT let wrapped source prose through. These real lines carry an uppercase
+    # shred letter glued to the code with no comma/space separator before the
+    # lowercase prose, and must still be rejected as ladder lines.
+    it "does not treat a glued-shred prose mention as a ladder line" do
+      record = <<~TXT
+        AFSC 45A4* Staff
+        AFSC 45A1* Entry
+                                      ANESTHESIOLOGIST
+                                      (Changed 30Apr 25)
+
+        1. Specialty Summary. Administers anesthesia.
+        3.4. Experience. For award ofAFSC 42B3Z requires successful completion of
+        3.5. For entry and retention ofAFSC 43E3Aand complete the education and/or
+      TXT
+      result = parse(record)
+      # Only the real 45A levels survive; the "42B3Z requires ..." and
+      # "43E3Aand ..." prose lines are not read as a ladder.
+      _(result[:qual_levels].keys.sort).must_equal [1, 4]
+    end
   end
 end


### PR DESCRIPTION
## Summary

- The DAFOCD qualification-ladder anchor required a comma between the concrete code and its title and couldn't absorb a glued shredout letter or a leading decorative glyph, so 6 live officer specialties were silently missed by extraction: `17DX`, `44BX`, `45AX`, `47BX`, `47PX`, `48GX`.
- The anchor now accepts a comma-or-whitespace separator (a bare optional comma would admit glued-shred prose elsewhere in the document), absorbs a trailing shred letter without folding it into the concrete code, and tolerates a leading Private Use Area glyph some cards carry before `AFSC`.
- Regenerated `officer.yml` adds the 6 specialties (130 -> 136 entries) with every existing entry byte-identical. The shred letter flows through as a shredout via each card's own shredout table (e.g. `17DXW` -> Warfighter Communications).

## Notes

- Verified against the source PDF directly, not from memory of the career fields.
- Negative tests confirm the loosened separator still rejects glued-shred prose lines that aren't real ladder entries.