### PR TITLE
Collapse default skill/qual-level titles in the release data

### DIFF
--- a/bin/extract_afsc_from_pdf.rb
+++ b/bin/extract_afsc_from_pdf.rb
@@ -26,9 +26,21 @@ require_relative "../lib/gov_codes/dafecd/text"
 require_relative "../lib/gov_codes/dafecd/title_degluer"
 require_relative "../lib/gov_codes/dafecd/shredout_degluer"
 require_relative "../lib/gov_codes/dafecd/ri_sdi/index_builder"
+require_relative "../lib/gov_codes/afsc/enlisted"
+require_relative "../lib/gov_codes/afsc/officer"
 
 # Human-readable label for the index header comment + report banner.
 INDEX_LABELS = {dafecd: "DAFECD enlisted", dafocd: "DAFOCD officer"}.freeze
+
+# The runtime's per-digit default ladder titles (single source of truth shared
+# with the Enlisted/Officer lookup fallback) -- a ladder rung's :title is
+# dropped from the generated index when it matches the default here, so the
+# generated data only carries a title for a rung when it deviates from the
+# standard nomenclature.
+DEFAULT_LEVEL_TITLES = {
+  dafecd: GovCodes::AFSC::Enlisted::SKILL_LEVELS,
+  dafocd: GovCodes::AFSC::Officer::QUAL_LEVELS
+}.freeze
 
 # A few representative specialty keys per publication for the sample section.
 SAMPLE_KEYS = {
@@ -46,6 +58,13 @@ def version_label_from(filename)
   filename[/\bv(\d+(?:\.\d+)?)/i]&.then { |m| "v#{m[/[\d.]+/]}" }
 end
 
+def strip_default_titles(levels, publication)
+  defaults = DEFAULT_LEVEL_TITLES.fetch(publication.id, {})
+  levels.to_h do |digit, level|
+    [digit, (level[:title] == defaults[digit]) ? {code: level[:code]} : level]
+  end
+end
+
 def clean_entry(entry, publication)
   levels_key = publication.levels_key
   # Ordered pairs (YAML key order matters); nil values are dropped, empty maps
@@ -56,7 +75,7 @@ def clean_entry(entry, publication)
     [:career_field, entry[:career_field]],
     [:cem_code, entry[:cem_code]],
     [:changed_date, entry[:changed_date]],
-    [levels_key, entry[levels_key].sort.to_h],
+    [levels_key, strip_default_titles(entry[levels_key].sort.to_h, publication)],
     [:shredouts, entry[:shredouts].sort_by { |k, _| k.to_s }.to_h],
     [:shredout_acronyms, entry[:shredout_acronyms]&.sort_by { |k, _| k.to_s }&.to_h]
   ].reject { |_, v| v.nil? }.to_h
@@ -73,7 +92,7 @@ def clean_ri_entry(entry)
     [:acronym, entry[:acronym]],
     [:changed_date, entry[:changed_date]],
     [:shredouts, shredouts.empty? ? nil : shredouts.sort_by { |k, _| k.to_s }.to_h],
-    [:shredout_acronyms, shredout_acronyms.nil? || shredout_acronyms.empty? ? nil : shredout_acronyms.sort_by { |k, _| k.to_s }.to_h]
+    [:shredout_acronyms, (shredout_acronyms.nil? || shredout_acronyms.empty?) ? nil : shredout_acronyms.sort_by { |k, _| k.to_s }.to_h]
   ].reject { |_, v| v.nil? }.to_h
 end
 

--- a/lib/gov_codes/afsc/enlisted.rb
+++ b/lib/gov_codes/afsc/enlisted.rb
@@ -9,7 +9,7 @@ module GovCodes
         3 => "Apprentice",
         5 => "Journeyman",
         7 => "Craftsman",
-        9 => "Senior Enlisted Leader"
+        9 => "Superintendent"
       }.freeze
 
       class Parser

--- a/lib/gov_codes/afsc/officer.rb
+++ b/lib/gov_codes/afsc/officer.rb
@@ -8,6 +8,17 @@ module GovCodes
     # or a literal bare code (e.g. :10C0) in the release in effect on +as_of+,
     # defaulting to today.
     module Officer
+      # Qualification levels 1 and 2 are deliberately absent: the DAFOCD ladder
+      # splits by flying vs. non-flying career fields at those rungs (e.g.
+      # "Entry/Student" and "Qualified Pilot/Copilot" for flying AFSCs vs.
+      # "Entry" and "Intermediate" elsewhere), so there is no single dominant
+      # title to default to. Don't add them back without re-checking the
+      # distribution across the current release data.
+      QUAL_LEVELS = {
+        3 => "Qualified",
+        4 => "Staff"
+      }.freeze
+
       class Parser
         def initialize(code)
           @code = code
@@ -124,7 +135,8 @@ module GovCodes
           if qual.match?(/\d/)
             number = Integer(qual)
             result[:qualification_level_number] = number
-            result[:qualification_level_name] = entry.dig(:qual_levels, number, :title)
+            result[:qualification_level_name] = entry.dig(:qual_levels, number, :title) ||
+              QUAL_LEVELS[number]
           end
 
           # Shredout meaning, only when the directory documents this shredout.

--- a/lib/gov_codes/afsc/releases/dafecd/2025-10-31/enlisted.yml
+++ b/lib/gov_codes/afsc/releases/dafecd/2025-10-31/enlisted.yml
@@ -13,16 +13,12 @@
   :skill_levels:
     1:
       :code: 1A112
-      :title: Helper
     3:
       :code: 1A132
-      :title: Apprentice
     5:
       :code: 1A152
-      :title: Journeyman
     7:
       :code: 1A172
-      :title: Craftsman
     9:
       :code: 1A192
       :title: Senior Enlisted Leader
@@ -50,16 +46,12 @@
   :skill_levels:
     1:
       :code: 1A113
-      :title: Helper
     3:
       :code: 1A133
-      :title: Apprentice
     5:
       :code: 1A153
-      :title: Journeyman
     7:
       :code: 1A173
-      :title: Craftsman
     9:
       :code: 1A193
       :title: Senior Enlisted Leader
@@ -82,19 +74,14 @@
   :skill_levels:
     1:
       :code: 1A114
-      :title: Helper
     3:
       :code: 1A134
-      :title: Apprentice
     5:
       :code: 1A154
-      :title: Journeyman
     7:
       :code: 1A174
-      :title: Craftsman
     9:
       :code: 1A194
-      :title: Superintendent
   :shredouts:
     :A: E-3G Radar/Comm/Mission Operator
     :B: E-3ARadar/Comm/Mission Operator
@@ -114,16 +101,12 @@
   :skill_levels:
     1:
       :code: 1A118
-      :title: Helper
     3:
       :code: 1A138
-      :title: Apprentice
     5:
       :code: 1A158
-      :title: Journeyman
     7:
       :code: 1A178
-      :title: Craftsman
     9:
       :code: 1A198
       :title: Senior Enlisted Leader
@@ -145,7 +128,6 @@
   :skill_levels:
     9:
       :code: 1A890
-      :title: Superintendent
   :shredouts: {}
 :1A8X1:
   :name: Airborne Cryptologic Language Analyst (ACLA)
@@ -155,7 +137,6 @@
   :skill_levels:
     1:
       :code: 1A811
-      :title: Helper
   :shredouts:
     :F: Arabic
     :G: Chinese
@@ -172,16 +153,12 @@
   :skill_levels:
     1:
       :code: 1A812
-      :title: Helper
     3:
       :code: 1A832
-      :title: Apprentice
     5:
       :code: 1A852
-      :title: Journeyman
     7:
       :code: 1A872
-      :title: Craftsman
   :shredouts: {}
 :1B4X1:
   :name: Cyber Warfare Operations
@@ -191,19 +168,14 @@
   :skill_levels:
     1:
       :code: 1B411
-      :title: Helper
     3:
       :code: 1B431
-      :title: Apprentice
     5:
       :code: 1B451
-      :title: Journeyman
     7:
       :code: 1B471
-      :title: Craftsman
     9:
       :code: 1B491
-      :title: Superintendent
   :shredouts: {}
 :1C0X2:
   :name: Aviation Resource Management
@@ -213,19 +185,14 @@
   :skill_levels:
     1:
       :code: 1C012
-      :title: Helper
     3:
       :code: 1C032
-      :title: Apprentice
     5:
       :code: 1C052
-      :title: Journeyman
     7:
       :code: 1C072
-      :title: Craftsman
     9:
       :code: 1C092
-      :title: Superintendent
   :shredouts: {}
 :1C1X1:
   :name: Air Traffic Control
@@ -235,19 +202,14 @@
   :skill_levels:
     1:
       :code: 1C111
-      :title: Helper
     3:
       :code: 1C131
-      :title: Apprentice
     5:
       :code: 1C151
-      :title: Journeyman
     7:
       :code: 1C171
-      :title: Craftsman
     9:
       :code: 1C191
-      :title: Superintendent
   :shredouts: {}
 :1C3X1:
   :name: All-Domain Command and Control Operations
@@ -257,19 +219,14 @@
   :skill_levels:
     1:
       :code: 1C311
-      :title: Helper
     3:
       :code: 1C331
-      :title: Apprentice
     5:
       :code: 1C351
-      :title: Journeyman
     7:
       :code: 1C371
-      :title: Craftsman
     9:
       :code: 1C391
-      :title: Superintendent
   :shredouts: {}
 :1C5X1:
   :name: Battle Management Operations
@@ -279,19 +236,14 @@
   :skill_levels:
     1:
       :code: 1C511
-      :title: Helper
     3:
       :code: 1C531
-      :title: Apprentice
     5:
       :code: 1C551
-      :title: Journeyman
     7:
       :code: 1C571
-      :title: Craftsman
     9:
       :code: 1C591
-      :title: Superintendent
   :shredouts:
     :D: Weapons Director
 :1C6X1:
@@ -302,19 +254,14 @@
   :skill_levels:
     1:
       :code: 1C611
-      :title: Helper
     3:
       :code: 1C631
-      :title: Apprentice
     5:
       :code: 1C651
-      :title: Journeyman
     7:
       :code: 1C671
-      :title: Craftsman
     9:
       :code: 1C691
-      :title: Superintendent
   :shredouts: {}
 :1C7X1:
   :name: Airfield Management
@@ -324,19 +271,14 @@
   :skill_levels:
     1:
       :code: 1C711
-      :title: Helper
     3:
       :code: 1C731
-      :title: Apprentice
     5:
       :code: 1C751
-      :title: Journeyman
     7:
       :code: 1C771
-      :title: Craftsman
     9:
       :code: 1C791
-      :title: Superintendent
   :shredouts: {}
 :1C8X3:
   :name: Radar, Airfield & Weather Systems (RAWS)
@@ -347,19 +289,14 @@
   :skill_levels:
     1:
       :code: 1C813
-      :title: Helper
     3:
       :code: 1C833
-      :title: Apprentice
     5:
       :code: 1C853
-      :title: Journeyman
     7:
       :code: 1C873
-      :title: Craftsman
     9:
       :code: 1C893
-      :title: Superintendent
   :shredouts: {}
 :1D7X1:
   :name: Warfighter Communications
@@ -369,19 +306,14 @@
   :skill_levels:
     1:
       :code: 1D711
-      :title: Helper
     3:
       :code: 1D731
-      :title: Apprentice
     5:
       :code: 1D751
-      :title: Journeyman
     7:
       :code: 1D771
-      :title: Craftsman
     9:
       :code: 1D791
-      :title: Superintendent
   :shredouts:
     :A: Network Operations
     :B: Systems Administration
@@ -392,16 +324,12 @@
   :skill_levels:
     1:
       :code: 1D712
-      :title: Helper
     3:
       :code: 1D732
-      :title: Apprentice
     5:
       :code: 1D752
-      :title: Journeyman
     7:
       :code: 1D772
-      :title: Craftsman
   :shredouts:
     :F: Spectrum Operations
     :R: RF Transmissions
@@ -412,16 +340,12 @@
   :skill_levels:
     1:
       :code: 1D713
-      :title: Helper
     3:
       :code: 1D733
-      :title: Apprentice
     5:
       :code: 1D753
-      :title: Journeyman
     7:
       :code: 1D773
-      :title: Craftsman
   :shredouts: {}
 :1D7X4:
   :name: Data Engineering
@@ -430,16 +354,12 @@
   :skill_levels:
     1:
       :code: 1D714
-      :title: Helper
     3:
       :code: 1D734
-      :title: Apprentice
     5:
       :code: 1D754
-      :title: Journeyman
     7:
       :code: 1D774
-      :title: Craftsman
   :shredouts:
     :D: Data Operations
     :P: Software Engineer
@@ -450,16 +370,12 @@
   :skill_levels:
     1:
       :code: 1D715
-      :title: Helper
     3:
       :code: 1D735
-      :title: Apprentice
     5:
       :code: 1D755
-      :title: Journeyman
     7:
       :code: 1D775
-      :title: Craftsman
   :shredouts: {}
 :1H0X1:
   :name: Aerospace Physiology
@@ -469,19 +385,14 @@
   :skill_levels:
     1:
       :code: 1H011
-      :title: Helper
     3:
       :code: 1H031
-      :title: Apprentice
     5:
       :code: 1H051
-      :title: Journeyman
     7:
       :code: 1H071
-      :title: Craftsman
     9:
       :code: 1H091
-      :title: Superintendent
   :shredouts: {}
 :1N0X1:
   :name: All Source Intelligence Analyst
@@ -490,16 +401,12 @@
   :skill_levels:
     1:
       :code: 1N011
-      :title: Helper
     3:
       :code: 1N031
-      :title: Apprentice
     5:
       :code: 1N051
-      :title: Journeyman
     7:
       :code: 1N071
-      :title: Craftsman
   :shredouts: {}
 :1N0X2:
   :name: Intelligence Superintendent
@@ -508,7 +415,6 @@
   :skill_levels:
     9:
       :code: 1N092
-      :title: Superintendent
   :shredouts: {}
 :1N1X1:
   :name: Geospatial Intelligence (GEOINT)
@@ -519,16 +425,12 @@
   :skill_levels:
     1:
       :code: 1N111
-      :title: Helper
     3:
       :code: 1N131
-      :title: Apprentice
     5:
       :code: 1N151
-      :title: Journeyman
     7:
       :code: 1N171
-      :title: Craftsman
   :shredouts:
     :A: Imagery Analyst
 :1N2X1:
@@ -538,16 +440,12 @@
   :skill_levels:
     1:
       :code: 1N211
-      :title: Helper
     3:
       :code: 1N231
-      :title: Apprentice
     5:
       :code: 1N251
-      :title: Journeyman
     7:
       :code: 1N271
-      :title: Craftsman
   :shredouts:
     :A: Electronic Non-Communications Analyst
     :C: Signals Analyst
@@ -558,7 +456,6 @@
   :skill_levels:
     9:
       :code: 1N292
-      :title: Superintendent
   :shredouts: {}
 :1N3X1:
   :name: Cryptologic Language Analyst
@@ -567,16 +464,12 @@
   :skill_levels:
     1:
       :code: 1N311
-      :title: Helper
     3:
       :code: 1N331
-      :title: Apprentice
     5:
       :code: 1N351
-      :title: Journeyman
     7:
       :code: 1N371
-      :title: Craftsman
   :shredouts:
     :F: Arabic
     :G: Chinese
@@ -593,16 +486,12 @@
   :skill_levels:
     1:
       :code: 1N411
-      :title: Helper
     3:
       :code: 1N431
-      :title: Apprentice
     5:
       :code: 1N451
-      :title: Journeyman
     7:
       :code: 1N471
-      :title: Craftsman
   :shredouts:
     :A: Analyst
 :1N4X2:
@@ -612,16 +501,12 @@
   :skill_levels:
     1:
       :code: 1N412
-      :title: Helper
     3:
       :code: 1N432
-      :title: Apprentice
     5:
       :code: 1N452
-      :title: Journeyman
     7:
       :code: 1N472
-      :title: Craftsman
   :shredouts: {}
 :1N7X1:
   :name: Human Intelligence Specialist
@@ -630,13 +515,10 @@
   :skill_levels:
     1:
       :code: 1N711
-      :title: Helper
     3:
       :code: 1N731
-      :title: Apprentice
     7:
       :code: 1N771
-      :title: Craftsman
   :shredouts: {}
 :1N8X1:
   :name: Targeting Analyst
@@ -646,16 +528,12 @@
   :skill_levels:
     1:
       :code: 1N811
-      :title: Helper
     3:
       :code: 1N831
-      :title: Apprentice
     5:
       :code: 1N851
-      :title: Journeyman
     7:
       :code: 1N871
-      :title: Craftsman
   :shredouts: {}
 :1P0X1:
   :name: Aircrew Flight Equipment
@@ -665,19 +543,14 @@
   :skill_levels:
     1:
       :code: 1P011
-      :title: Helper
     3:
       :code: 1P031
-      :title: Apprentice
     5:
       :code: 1P051
-      :title: Journeyman
     7:
       :code: 1P071
-      :title: Craftsman
     9:
       :code: 1P091
-      :title: Superintendent
   :shredouts:
     :A: Ejection Seat Aircraft
     :B: Non-Ejection Seat Aircraft
@@ -689,19 +562,14 @@
   :skill_levels:
     1:
       :code: 1S011
-      :title: Helper
     3:
       :code: 1S031
-      :title: Apprentice
     5:
       :code: 1S051
-      :title: Journeyman
     7:
       :code: 1S071
-      :title: Craftsman
     9:
       :code: 1S091
-      :title: Superintendent
   :shredouts: {}
 :1T0X1:
   :name: Survival, Evasion, Resistance, Escape (SERE) Specialist
@@ -711,19 +579,14 @@
   :skill_levels:
     1:
       :code: 1T011
-      :title: Helper
     3:
       :code: 1T031
-      :title: Apprentice
     5:
       :code: 1T051
-      :title: Journeyman
     7:
       :code: 1T071
-      :title: Craftsman
     9:
       :code: 1T091
-      :title: Superintendent
   :shredouts: {}
 :1U1X1:
   :name: Remotely Piloted Aircraft (RPA) Pilot
@@ -732,19 +595,14 @@
   :skill_levels:
     1:
       :code: 1U111
-      :title: Helper
     3:
       :code: 1U131
-      :title: Apprentice
     5:
       :code: 1U151
-      :title: Journeyman
     7:
       :code: 1U171
-      :title: Craftsman
     9:
       :code: 1U191
-      :title: Superintendent
   :shredouts:
     :O: RQ-4
     :R: MQ-9
@@ -756,19 +614,14 @@
   :skill_levels:
     1:
       :code: 1W011
-      :title: Helper
     3:
       :code: 1W031
-      :title: Apprentice
     5:
       :code: 1W051
-      :title: Journeyman
     7:
       :code: 1W071
-      :title: Craftsman
     9:
       :code: 1W091
-      :title: Superintendent
   :shredouts: {}
 :1Z1X1:
   :name: Pararescue
@@ -778,19 +631,14 @@
   :skill_levels:
     1:
       :code: 1Z111
-      :title: Helper
     3:
       :code: 1Z131
-      :title: Apprentice
     5:
       :code: 1Z151
-      :title: Journeyman
     7:
       :code: 1Z171
-      :title: Craftsman
     9:
       :code: 1Z191
-      :title: Superintendent
   :shredouts: {}
 :1Z2X1:
   :name: Combat Control
@@ -800,19 +648,14 @@
   :skill_levels:
     1:
       :code: 1Z211
-      :title: Helper
     3:
       :code: 1Z231
-      :title: Apprentice
     5:
       :code: 1Z251
-      :title: Journeyman
     7:
       :code: 1Z271
-      :title: Craftsman
     9:
       :code: 1Z291
-      :title: Superintendent
   :shredouts: {}
 :1Z3X1:
   :name: Tactical Air Control Party (TACP)
@@ -823,19 +666,14 @@
   :skill_levels:
     1:
       :code: 1Z311
-      :title: Helper
     3:
       :code: 1Z331
-      :title: Apprentice
     5:
       :code: 1Z351
-      :title: Journeyman
     7:
       :code: 1Z371
-      :title: Craftsman
     9:
       :code: 1Z391
-      :title: Superintendent
   :shredouts: {}
 :1Z4X1:
   :name: Special Reconnaissance
@@ -845,19 +683,14 @@
   :skill_levels:
     1:
       :code: 1Z411
-      :title: Helper
     3:
       :code: 1Z431
-      :title: Apprentice
     5:
       :code: 1Z451
-      :title: Journeyman
     7:
       :code: 1Z471
-      :title: Craftsman
     9:
       :code: 1Z491
-      :title: Superintendent
   :shredouts: {}
 :2A0X0:
   :name: Avionics
@@ -866,7 +699,6 @@
   :skill_levels:
     9:
       :code: 2A090
-      :title: Superintendent
   :shredouts: {}
 :2A0X1:
   :name: Avionics Test Station, Components, and Electronic Warfare Systems
@@ -875,16 +707,12 @@
   :skill_levels:
     1:
       :code: 2A011
-      :title: Helper
     3:
       :code: 2A031
-      :title: Apprentice
     5:
       :code: 2A051
-      :title: Journeyman
     7:
       :code: 2A071
-      :title: Craftsman
   :shredouts: {}
 :2A2X1:
   :name: MHU-139 Electrical, Environmental and Avionics Technician
@@ -893,13 +721,10 @@
   :skill_levels:
     1:
       :code: 2A211
-      :title: Helper
     3:
       :code: 2A231
-      :title: Apprentice
     5:
       :code: 2A251
-      :title: Journeyman
   :shredouts: {}
 :2A3X0:
   :name: Fighter Aircraft Maintenance
@@ -909,7 +734,6 @@
   :skill_levels:
     9:
       :code: 2A390
-      :title: Superintendent
   :shredouts: {}
 :2A3X3:
   :name: Tactical Aircraft Maintenance
@@ -918,16 +742,12 @@
   :skill_levels:
     1:
       :code: 2A313
-      :title: Helper
     3:
       :code: 2A333
-      :title: Apprentice
     5:
       :code: 2A353
-      :title: Journeyman
     7:
       :code: 2A373
-      :title: Craftsman
   :shredouts:
     :E: A-10/U-2
     :L: F-15
@@ -939,16 +759,12 @@
   :skill_levels:
     1:
       :code: 2A314
-      :title: Helper
     3:
       :code: 2A334
-      :title: Apprentice
     5:
       :code: 2A354
-      :title: Journeyman
     7:
       :code: 2A374
-      :title: Craftsman
   :shredouts:
     :A: A-10/U-2Avionics
     :B: F-15Avionics
@@ -960,16 +776,12 @@
   :skill_levels:
     1:
       :code: 2A315
-      :title: Helper
     3:
       :code: 2A335
-      :title: Apprentice
     5:
       :code: 2A355
-      :title: Journeyman
     7:
       :code: 2A375
-      :title: Craftsman
   :shredouts:
     :A: F-22
     :B: F-35
@@ -980,16 +792,12 @@
   :skill_levels:
     1:
       :code: 2A317
-      :title: Helper
     3:
       :code: 2A337
-      :title: Apprentice
     5:
       :code: 2A357
-      :title: Journeyman
     7:
       :code: 2A377
-      :title: Craftsman
   :shredouts:
     :A: F-22
     :B: F-35
@@ -1001,7 +809,6 @@
   :skill_levels:
     9:
       :code: 2A590
-      :title: Superintendent
   :shredouts: {}
 :2A5X1:
   :name: Airlift/Special Mission Aircraft Maintenance
@@ -1010,16 +817,12 @@
   :skill_levels:
     1:
       :code: 2A511
-      :title: Helper
     3:
       :code: 2A531
-      :title: Apprentice
     5:
       :code: 2A551
-      :title: Journeyman
     7:
       :code: 2A571
-      :title: Craftsman
   :shredouts:
     :A: C-20/C-21/C-22/C-37/C-40/E-4/VC- 25
     :B: C-130/C-27J
@@ -1034,16 +837,12 @@
   :skill_levels:
     1:
       :code: 2A512
-      :title: Helper
     3:
       :code: 2A532
-      :title: Apprentice
     5:
       :code: 2A552
-      :title: Journeyman
     7:
       :code: 2A572
-      :title: Craftsman
   :shredouts:
     :B: H-60
     :D: CV-22
@@ -1055,16 +854,12 @@
   :skill_levels:
     1:
       :code: 2A514
-      :title: Helper
     3:
       :code: 2A534
-      :title: Apprentice
     5:
       :code: 2A554
-      :title: Journeyman
     7:
       :code: 2A574
-      :title: Craftsman
   :shredouts:
     :A: Any C-135/E-3/E-8
     :B: KC-10
@@ -1080,7 +875,6 @@
   :skill_levels:
     9:
       :code: 2A690
-      :title: Superintendent
   :shredouts: {}
 :2A6X1:
   :name: Aerospace Propulsion
@@ -1089,19 +883,14 @@
   :skill_levels:
     1:
       :code: 2A611
-      :title: Helper
     3:
       :code: 2A631
-      :title: Apprentice
     5:
       :code: 2A651
-      :title: Journeyman
     7:
       :code: 2A671
-      :title: Craftsman
     9:
       :code: 2A691
-      :title: Superintendent
   :shredouts: {}
 :2A6X2:
   :name: Aerospace Ground Equipment
@@ -1110,19 +899,14 @@
   :skill_levels:
     1:
       :code: 2A612
-      :title: Helper
     3:
       :code: 2A632
-      :title: Apprentice
     5:
       :code: 2A652
-      :title: Journeyman
     7:
       :code: 2A672
-      :title: Craftsman
     9:
       :code: 2A692
-      :title: Superintendent
   :shredouts: {}
 :2A6X3:
   :name: Aircrew Egress Systems
@@ -1131,16 +915,12 @@
   :skill_levels:
     1:
       :code: 2A613
-      :title: Helper
     3:
       :code: 2A633
-      :title: Apprentice
     5:
       :code: 2A653
-      :title: Journeyman
     7:
       :code: 2A673
-      :title: Craftsman
   :shredouts: {}
 :2A6X4:
   :name: Aircraft Fuel Systems
@@ -1149,16 +929,12 @@
   :skill_levels:
     1:
       :code: 2A614
-      :title: Helper
     3:
       :code: 2A634
-      :title: Apprentice
     5:
       :code: 2A654
-      :title: Journeyman
     7:
       :code: 2A674
-      :title: Craftsman
   :shredouts: {}
 :2A6X5:
   :name: Aircraft Hydraulic Systems
@@ -1167,16 +943,12 @@
   :skill_levels:
     1:
       :code: 2A615
-      :title: Helper
     3:
       :code: 2A635
-      :title: Apprentice
     5:
       :code: 2A655
-      :title: Journeyman
     7:
       :code: 2A675
-      :title: Craftsman
   :shredouts: {}
 :2A6X6:
   :name: Aircraft Electrical and Environmental Systems
@@ -1185,16 +957,12 @@
   :skill_levels:
     1:
       :code: 2A616
-      :title: Helper
     3:
       :code: 2A636
-      :title: Apprentice
     5:
       :code: 2A656
-      :title: Journeyman
     7:
       :code: 2A676
-      :title: Craftsman
   :shredouts: {}
 :2A7X0:
   :name: Aircraft Fabrication
@@ -1203,7 +971,6 @@
   :skill_levels:
     9:
       :code: 2A790
-      :title: Superintendent
   :shredouts: {}
 :2A7X1:
   :name: Aircraft Metals Technology
@@ -1212,16 +979,12 @@
   :skill_levels:
     1:
       :code: 2A711
-      :title: Helper
     3:
       :code: 2A731
-      :title: Apprentice
     5:
       :code: 2A751
-      :title: Journeyman
     7:
       :code: 2A771
-      :title: Craftsman
   :shredouts: {}
 :2A7X2:
   :name: Nondestructive Inspection
@@ -1230,16 +993,12 @@
   :skill_levels:
     1:
       :code: 2A712
-      :title: Helper
     3:
       :code: 2A732
-      :title: Apprentice
     5:
       :code: 2A752
-      :title: Journeyman
     7:
       :code: 2A772
-      :title: Craftsman
   :shredouts: {}
 :2A7X3:
   :name: Aircraft Structural Maintenance
@@ -1248,16 +1007,12 @@
   :skill_levels:
     1:
       :code: 2A713
-      :title: Helper
     3:
       :code: 2A733
-      :title: Apprentice
     5:
       :code: 2A753
-      :title: Journeyman
     7:
       :code: 2A773
-      :title: Craftsman
   :shredouts: {}
 :2A9X4:
   :name: Heavy Aircraft Integrated Avionics
@@ -1266,16 +1021,12 @@
   :skill_levels:
     1:
       :code: 2A914
-      :title: Helper
     3:
       :code: 2A934
-      :title: Apprentice
     5:
       :code: 2A954
-      :title: Journeyman
     7:
       :code: 2A974
-      :title: Craftsman
   :shredouts: {}
 :2F0X1:
   :name: Fuels
@@ -1285,19 +1036,14 @@
   :skill_levels:
     1:
       :code: 2F011
-      :title: Helper
     3:
       :code: 2F031
-      :title: Apprentice
     5:
       :code: 2F051
-      :title: Journeyman
     7:
       :code: 2F071
-      :title: Craftsman
     9:
       :code: 2F091
-      :title: Superintendent
   :shredouts: {}
 :2G0X1:
   :name: Logistics Plans
@@ -1307,19 +1053,14 @@
   :skill_levels:
     1:
       :code: 2G011
-      :title: Helper
     3:
       :code: 2G031
-      :title: Apprentice
     5:
       :code: 2G051
-      :title: Journeyman
     7:
       :code: 2G071
-      :title: Craftsman
     9:
       :code: 2G091
-      :title: Superintendent
   :shredouts: {}
 :2M0X0:
   :name: Missile and Space Systems Maintenance
@@ -1329,7 +1070,6 @@
   :skill_levels:
     9:
       :code: 2M090
-      :title: Superintendent
   :shredouts: {}
 :2M0X1:
   :name: Missile and Space Systems Electronic Maintenance
@@ -1338,16 +1078,12 @@
   :skill_levels:
     1:
       :code: 2M011
-      :title: Helper
     3:
       :code: 2M031
-      :title: Apprentice
     5:
       :code: 2M051
-      :title: Journeyman
     7:
       :code: 2M071
-      :title: Craftsman
   :shredouts:
     :A: ICBM
     :B: ALCM
@@ -1358,16 +1094,12 @@
   :skill_levels:
     1:
       :code: 2M012
-      :title: Helper
     3:
       :code: 2M032
-      :title: Apprentice
     5:
       :code: 2M052
-      :title: Journeyman
     7:
       :code: 2M072
-      :title: Craftsman
   :shredouts: {}
 :2M0X3:
   :name: Missile and Space Facilities
@@ -1376,16 +1108,12 @@
   :skill_levels:
     1:
       :code: 2M013
-      :title: Helper
     3:
       :code: 2M033
-      :title: Apprentice
     5:
       :code: 2M053
-      :title: Journeyman
     7:
       :code: 2M073
-      :title: Craftsman
   :shredouts: {}
 :2P0X1:
   :name: Precision Measurement Equipment Laboratory
@@ -1395,19 +1123,14 @@
   :skill_levels:
     1:
       :code: 2P011
-      :title: Helper
     3:
       :code: 2P031
-      :title: Apprentice
     5:
       :code: 2P051
-      :title: Journeyman
     7:
       :code: 2P071
-      :title: Craftsman
     9:
       :code: 2P091
-      :title: Superintendent
   :shredouts: {}
 :2R2X1:
   :name: Maintenance Management
@@ -1420,16 +1143,12 @@
       :title: Entry
     3:
       :code: 2R231
-      :title: Apprentice
     5:
       :code: 2R251
-      :title: Journeyman
     7:
       :code: 2R271
-      :title: Craftsman
     9:
       :code: 2R291
-      :title: Superintendent
   :shredouts: {}
 :2S0X1:
   :name: Materiel Management
@@ -1439,19 +1158,14 @@
   :skill_levels:
     1:
       :code: 2S011
-      :title: Helper
     3:
       :code: 2S031
-      :title: Apprentice
     5:
       :code: 2S051
-      :title: Journeyman
     7:
       :code: 2S071
-      :title: Craftsman
     9:
       :code: 2S091
-      :title: Superintendent
   :shredouts: {}
 :2T0X1:
   :name: Traffic Management Operations
@@ -1461,19 +1175,14 @@
   :skill_levels:
     1:
       :code: 2T011
-      :title: Helper
     3:
       :code: 2T031
-      :title: Apprentice
     5:
       :code: 2T051
-      :title: Journeyman
     7:
       :code: 2T071
-      :title: Craftsman
     9:
       :code: 2T091
-      :title: Superintendent
   :shredouts: {}
 :2T1X1:
   :name: Ground Transportation
@@ -1483,19 +1192,14 @@
   :skill_levels:
     1:
       :code: 2T111
-      :title: Helper
     3:
       :code: 2T131
-      :title: Apprentice
     5:
       :code: 2T151
-      :title: Journeyman
     7:
       :code: 2T171
-      :title: Craftsman
     9:
       :code: 2T191
-      :title: Superintendent
   :shredouts: {}
 :2T2X1:
   :name: Air Transportation
@@ -1505,19 +1209,14 @@
   :skill_levels:
     1:
       :code: 2T211
-      :title: Helper
     3:
       :code: 2T231
-      :title: Apprentice
     5:
       :code: 2T251
-      :title: Journeyman
     7:
       :code: 2T271
-      :title: Craftsman
     9:
       :code: 2T291
-      :title: Superintendent
   :shredouts: {}
 :2T3X0:
   :name: Vehicle Management
@@ -1526,7 +1225,6 @@
   :skill_levels:
     9:
       :code: 2T390
-      :title: Superintendent
   :shredouts: {}
 :2T3X1:
   :name: Mission Generation Vehicular Equipment Maintenance
@@ -1535,16 +1233,12 @@
   :skill_levels:
     1:
       :code: 2T311
-      :title: Helper
     3:
       :code: 2T331
-      :title: Apprentice
     5:
       :code: 2T351
-      :title: Journeyman
     7:
       :code: 2T371
-      :title: Craftsman
   :shredouts: {}
 :2T3X7:
   :name: Fleet Management and Analysis
@@ -1553,16 +1247,12 @@
   :skill_levels:
     1:
       :code: 2T317
-      :title: Helper
     3:
       :code: 2T337
-      :title: Apprentice
     5:
       :code: 2T357
-      :title: Journeyman
     7:
       :code: 2T377
-      :title: Craftsman
   :shredouts: {}
 :2W0X1:
   :name: Munitions Systems
@@ -1572,19 +1262,14 @@
   :skill_levels:
     1:
       :code: 2W011
-      :title: Helper
     3:
       :code: 2W031
-      :title: Apprentice
     5:
       :code: 2W051
-      :title: Journeyman
     7:
       :code: 2W071
-      :title: Craftsman
     9:
       :code: 2W091
-      :title: Superintendent
   :shredouts: {}
 :2W1X1:
   :name: Aircraft Armament Systems
@@ -1594,19 +1279,14 @@
   :skill_levels:
     1:
       :code: 2W111
-      :title: Helper
     3:
       :code: 2W131
-      :title: Apprentice
     5:
       :code: 2W151
-      :title: Journeyman
     7:
       :code: 2W171
-      :title: Craftsman
     9:
       :code: 2W191
-      :title: Superintendent
   :shredouts:
     :C: A-10
     :E: F-15
@@ -1625,19 +1305,14 @@
   :skill_levels:
     1:
       :code: 2W211
-      :title: Helper
     3:
       :code: 2W231
-      :title: Apprentice
     5:
       :code: 2W251
-      :title: Journeyman
     7:
       :code: 2W271
-      :title: Craftsman
     9:
       :code: 2W291
-      :title: Superintendent
   :shredouts: {}
 :3E0X0:
   :name: Facility Systems
@@ -1647,7 +1322,6 @@
   :skill_levels:
     9:
       :code: 3E090
-      :title: Superintendent
   :shredouts: {}
 :3E0X1:
   :name: Electrical Systems
@@ -1656,16 +1330,12 @@
   :skill_levels:
     1:
       :code: 3E011
-      :title: Helper
     3:
       :code: 3E031
-      :title: Apprentice
     5:
       :code: 3E051
-      :title: Journeyman
     7:
       :code: 3E071
-      :title: Craftsman
   :shredouts: {}
 :3E0X2:
   :name: Electrical Power Production
@@ -1674,16 +1344,12 @@
   :skill_levels:
     1:
       :code: 3E012
-      :title: Helper
     3:
       :code: 3E032
-      :title: Apprentice
     5:
       :code: 3E052
-      :title: Journeyman
     7:
       :code: 3E072
-      :title: Craftsman
   :shredouts: {}
 :3E1X1:
   :name: Heating, Ventilation, Air Conditioning, and Refrigeration
@@ -1692,16 +1358,12 @@
   :skill_levels:
     1:
       :code: 3E111
-      :title: Helper
     3:
       :code: 3E131
-      :title: Apprentice
     5:
       :code: 3E151
-      :title: Journeyman
     7:
       :code: 3E171
-      :title: Craftsman
   :shredouts: {}
 :3E2X0:
   :name: Heavy Repair
@@ -1711,7 +1373,6 @@
   :skill_levels:
     9:
       :code: 3E290
-      :title: Superintendent
   :shredouts: {}
 :3E2X1:
   :name: Pavements and Construction Equipment
@@ -1719,16 +1380,12 @@
   :skill_levels:
     1:
       :code: 3E211
-      :title: Helper
     3:
       :code: 3E231
-      :title: Apprentice
     5:
       :code: 3E251
-      :title: Journeyman
     7:
       :code: 3E271
-      :title: Craftsman
   :shredouts: {}
 :3E3X1:
   :name: Structural
@@ -1736,16 +1393,12 @@
   :skill_levels:
     1:
       :code: 3E311
-      :title: Helper
     3:
       :code: 3E331
-      :title: Apprentice
     5:
       :code: 3E351
-      :title: Journeyman
     7:
       :code: 3E371
-      :title: Craftsman
   :shredouts: {}
 :3E4X0:
   :name: Infrastructure Systems
@@ -1755,7 +1408,6 @@
   :skill_levels:
     9:
       :code: 3E490
-      :title: Superintendent
   :shredouts: {}
 :3E4X1:
   :name: Water and Fuel Systems Maintenance
@@ -1764,16 +1416,12 @@
   :skill_levels:
     1:
       :code: 3E411
-      :title: Helper
     3:
       :code: 3E431
-      :title: Apprentice
     5:
       :code: 3E451
-      :title: Journeyman
     7:
       :code: 3E471
-      :title: Craftsman
   :shredouts:
     :A: Fuel Systems Maintenance
 :3E4X3:
@@ -1782,16 +1430,12 @@
   :skill_levels:
     1:
       :code: 3E413
-      :title: Helper
     3:
       :code: 3E433
-      :title: Apprentice
     5:
       :code: 3E453
-      :title: Journeyman
     7:
       :code: 3E473
-      :title: Craftsman
   :shredouts: {}
 :3E5X1:
   :name: Engineering
@@ -1801,19 +1445,14 @@
   :skill_levels:
     1:
       :code: 3E511
-      :title: Helper
     3:
       :code: 3E531
-      :title: Apprentice
     5:
       :code: 3E551
-      :title: Journeyman
     7:
       :code: 3E571
-      :title: Craftsman
     9:
       :code: 3E591
-      :title: Superintendent
   :shredouts: {}
 :3E6X1:
   :name: Operations Management
@@ -1823,19 +1462,14 @@
   :skill_levels:
     1:
       :code: 3E611
-      :title: Helper
     3:
       :code: 3E631
-      :title: Apprentice
     5:
       :code: 3E651
-      :title: Journeyman
     7:
       :code: 3E671
-      :title: Craftsman
     9:
       :code: 3E691
-      :title: Superintendent
   :shredouts: {}
 :3E7X1:
   :name: Fire Protection
@@ -1845,19 +1479,14 @@
   :skill_levels:
     1:
       :code: 3E711
-      :title: Helper
     3:
       :code: 3E731
-      :title: Apprentice
     5:
       :code: 3E751
-      :title: Journeyman
     7:
       :code: 3E771
-      :title: Craftsman
     9:
       :code: 3E791
-      :title: Superintendent
   :shredouts: {}
 :3E8X1:
   :name: Explosive Ordnance Disposal
@@ -1867,19 +1496,14 @@
   :skill_levels:
     1:
       :code: 3E811
-      :title: Helper
     3:
       :code: 3E831
-      :title: Apprentice
     5:
       :code: 3E851
-      :title: Journeyman
     7:
       :code: 3E871
-      :title: Craftsman
     9:
       :code: 3E891
-      :title: Superintendent
   :shredouts: {}
 :3E9X1:
   :name: Emergency Management
@@ -1889,19 +1513,14 @@
   :skill_levels:
     1:
       :code: 3E911
-      :title: Helper
     3:
       :code: 3E931
-      :title: Apprentice
     5:
       :code: 3E951
-      :title: Journeyman
     7:
       :code: 3E971
-      :title: Craftsman
     9:
       :code: 3E991
-      :title: Superintendent
   :shredouts: {}
 :3F0X1:
   :name: Human Resources and Administration
@@ -1911,19 +1530,14 @@
   :skill_levels:
     1:
       :code: 3F011
-      :title: Helper
     3:
       :code: 3F031
-      :title: Apprentice
     5:
       :code: 3F051
-      :title: Journeyman
     7:
       :code: 3F071
-      :title: Craftsman
     9:
       :code: 3F091
-      :title: Superintendent
   :shredouts: {}
 :3F1X1:
   :name: Services
@@ -1933,19 +1547,14 @@
   :skill_levels:
     1:
       :code: 3F111
-      :title: Helper
     3:
       :code: 3F131
-      :title: Apprentice
     5:
       :code: 3F151
-      :title: Journeyman
     7:
       :code: 3F171
-      :title: Craftsman
     9:
       :code: 3F191
-      :title: Superintendent
   :shredouts: {}
 :3F2X1:
   :name: Education and Training
@@ -1954,19 +1563,14 @@
   :skill_levels:
     1:
       :code: 3F211
-      :title: Helper
     3:
       :code: 3F231
-      :title: Apprentice
     5:
       :code: 3F251
-      :title: Journeyman
     7:
       :code: 3F271
-      :title: Craftsman
     9:
       :code: 3F291
-      :title: Superintendent
   :shredouts: {}
 :3F3X1:
   :name: Manpower
@@ -1976,19 +1580,14 @@
   :skill_levels:
     1:
       :code: 3F311
-      :title: Helper
     3:
       :code: 3F331
-      :title: Apprentice
     5:
       :code: 3F351
-      :title: Journeyman
     7:
       :code: 3F371
-      :title: Craftsman
     9:
       :code: 3F391
-      :title: Superintendent
   :shredouts:
     :M: Management Engineering/Data Analytics
 :3F4X1:
@@ -1999,16 +1598,13 @@
   :skill_levels:
     1:
       :code: 3F411
-      :title: Helper
     3:
       :code: 3F431
       :title: Journeyman
     7:
       :code: 3F471
-      :title: Craftsman
     9:
       :code: 3F491
-      :title: Superintendent
   :shredouts: {}
 :3G0X1:
   :name: Talent Acquisition
@@ -2018,19 +1614,14 @@
   :skill_levels:
     1:
       :code: 3G011
-      :title: Helper
     3:
       :code: 3G031
-      :title: Apprentice
     5:
       :code: 3G051
-      :title: Journeyman
     7:
       :code: 3G071
-      :title: Craftsman
     9:
       :code: 3G091
-      :title: Superintendent
   :shredouts: {}
 :3H0X1:
   :name: Historian
@@ -2039,19 +1630,14 @@
   :skill_levels:
     1:
       :code: 3H011
-      :title: Helper
     3:
       :code: 3H031
-      :title: Apprentice
     5:
       :code: 3H051
-      :title: Journeyman
     7:
       :code: 3H071
-      :title: Craftsman
     9:
       :code: 3H091
-      :title: Superintendent
   :shredouts: {}
 :3N0X0:
   :name: Public Affairs
@@ -2061,7 +1647,6 @@
   :skill_levels:
     9:
       :code: 3N090
-      :title: Superintendent
   :shredouts: {}
 :3N0X6:
   :name: Public Affairs
@@ -2070,16 +1655,12 @@
   :skill_levels:
     1:
       :code: 3N016
-      :title: Helper
     3:
       :code: 3N036
-      :title: Apprentice
     5:
       :code: 3N056
-      :title: Journeyman
     7:
       :code: 3N076
-      :title: Craftsman
   :shredouts: {}
 :3N1X1:
   :name: Regional Band
@@ -2089,19 +1670,14 @@
   :skill_levels:
     1:
       :code: 3N111
-      :title: Helper
     3:
       :code: 3N131
-      :title: Apprentice
     5:
       :code: 3N151
-      :title: Journeyman
     7:
       :code: 3N171
-      :title: Craftsman
     9:
       :code: 3N191
-      :title: Superintendent
   :shredouts:
     :A: Clarinet
     :B: Saxophone
@@ -2130,13 +1706,10 @@
   :skill_levels:
     5:
       :code: 3N251
-      :title: Journeyman
     7:
       :code: 3N271
-      :title: Craftsman
     9:
       :code: 3N291
-      :title: Superintendent
   :shredouts: {}
 :3N3X1:
   :name: Premier Band - The USAF Academy Band
@@ -2146,13 +1719,10 @@
   :skill_levels:
     5:
       :code: 3N351
-      :title: Journeyman
     7:
       :code: 3N371
-      :title: Craftsman
     9:
       :code: 3N391
-      :title: Superintendent
   :shredouts: {}
 :3P0X1:
   :name: Security Forces
@@ -2162,19 +1732,14 @@
   :skill_levels:
     1:
       :code: 3P011
-      :title: Helper
     3:
       :code: 3P031
-      :title: Apprentice
     5:
       :code: 3P051
-      :title: Journeyman
     7:
       :code: 3P071
-      :title: Craftsman
     9:
       :code: 3P091
-      :title: Superintendent
   :shredouts:
     :A: Military Working Dog Handler
     :B: Combat Arms
@@ -2186,19 +1751,14 @@
   :skill_levels:
     1:
       :code: 4A011
-      :title: Helper
     3:
       :code: 4A031
-      :title: Apprentice
     5:
       :code: 4A051
-      :title: Journeyman
     7:
       :code: 4A071
-      :title: Craftsman
     9:
       :code: 4A091
-      :title: Superintendent
   :shredouts:
     :S: Health Information Technology
 :4A1X1:
@@ -2208,19 +1768,14 @@
   :skill_levels:
     1:
       :code: 4A111
-      :title: Helper
     3:
       :code: 4A131
-      :title: Apprentice
     5:
       :code: 4A151
-      :title: Journeyman
     7:
       :code: 4A171
-      :title: Craftsman
     9:
       :code: 4A191
-      :title: Superintendent
   :shredouts: {}
 :4A2X1:
   :name: Biomedical Equipment
@@ -2230,19 +1785,14 @@
   :skill_levels:
     1:
       :code: 4A211
-      :title: Helper
     3:
       :code: 4A231
-      :title: Apprentice
     5:
       :code: 4A251
-      :title: Journeyman
     7:
       :code: 4A271
-      :title: Craftsman
     9:
       :code: 4A291
-      :title: Superintendent
   :shredouts: {}
 :4B0X1:
   :name: Bioenvironmental Engineering (BE)
@@ -2253,19 +1803,14 @@
   :skill_levels:
     1:
       :code: 4B011
-      :title: Helper
     3:
       :code: 4B031
-      :title: Apprentice
     5:
       :code: 4B051
-      :title: Journeyman
     7:
       :code: 4B071
-      :title: Craftsman
     9:
       :code: 4B091
-      :title: Superintendent
   :shredouts: {}
 :4C0X1:
   :name: Mental Health Service
@@ -2275,19 +1820,14 @@
   :skill_levels:
     1:
       :code: 4C011
-      :title: Helper
     3:
       :code: 4C031
-      :title: Apprentice
     5:
       :code: 4C051
-      :title: Journeyman
     7:
       :code: 4C071
-      :title: Craftsman
     9:
       :code: 4C091
-      :title: Superintendent
   :shredouts: {}
 :4D0X1:
   :name: Diet Therapy
@@ -2297,19 +1837,14 @@
   :skill_levels:
     1:
       :code: 4D011
-      :title: Helper
     3:
       :code: 4D031
-      :title: Apprentice
     5:
       :code: 4D051
-      :title: Journeyman
     7:
       :code: 4D071
-      :title: Craftsman
     9:
       :code: 4D091
-      :title: Superintendent
   :shredouts: {}
 :4E0X1:
   :name: Public Health
@@ -2319,19 +1854,14 @@
   :skill_levels:
     1:
       :code: 4E011
-      :title: Helper
     3:
       :code: 4E031
-      :title: Apprentice
     5:
       :code: 4E051
-      :title: Journeyman
     7:
       :code: 4E071
-      :title: Craftsman
     9:
       :code: 4E091
-      :title: Superintendent
   :shredouts: {}
 :4H0X1:
   :name: Respiratory Care Practitioner
@@ -2340,19 +1870,14 @@
   :skill_levels:
     1:
       :code: 4H011
-      :title: Helper
     3:
       :code: 4H031
-      :title: Apprentice
     5:
       :code: 4H051
-      :title: Journeyman
     7:
       :code: 4H071
-      :title: Craftsman
     9:
       :code: 4H091
-      :title: Superintendent
   :shredouts: {}
 :4J0X2:
   :name: Physical Medicine
@@ -2362,19 +1887,14 @@
   :skill_levels:
     1:
       :code: 4J012
-      :title: Helper
     3:
       :code: 4J032
-      :title: Apprentice
     5:
       :code: 4J052
-      :title: Journeyman
     7:
       :code: 4J072
-      :title: Craftsman
     9:
       :code: 4J090
-      :title: Superintendent
   :shredouts:
     :A: Orthotic
 :4N0X1:
@@ -2385,19 +1905,14 @@
   :skill_levels:
     1:
       :code: 4N011
-      :title: Helper
     3:
       :code: 4N031
-      :title: Apprentice
     5:
       :code: 4N051
-      :title: Journeyman
     7:
       :code: 4N071
-      :title: Craftsman
     9:
       :code: 4N091
-      :title: Superintendent
   :shredouts:
     :B: Neurodiagnostic Medical Technician
     :C: Independent Duty Medical Technician
@@ -2413,19 +1928,14 @@
   :skill_levels:
     1:
       :code: 4N111
-      :title: Helper
     3:
       :code: 4N131
-      :title: Apprentice
     5:
       :code: 4N151
-      :title: Journeyman
     7:
       :code: 4N171
-      :title: Craftsman
     9:
       :code: 4N191
-      :title: Superintendent
   :shredouts:
     :B: Urology
     :C: Orthopedics
@@ -2438,19 +1948,14 @@
   :skill_levels:
     1:
       :code: 4P011
-      :title: Helper
     3:
       :code: 4P031
-      :title: Apprentice
     5:
       :code: 4P051
-      :title: Journeyman
     7:
       :code: 4P071
-      :title: Craftsman
     9:
       :code: 4P091
-      :title: Superintendent
   :shredouts: {}
 :4R0X1:
   :name: Diagnostic Imaging
@@ -2460,19 +1965,14 @@
   :skill_levels:
     1:
       :code: 4R011
-      :title: Helper
     3:
       :code: 4R031
-      :title: Apprentice
     5:
       :code: 4R051
-      :title: Journeyman
     7:
       :code: 4R071
-      :title: Craftsman
     9:
       :code: 4R090
-      :title: Superintendent
   :shredouts:
     :A: Nuclear Medicine
     :B: Diagnostic Medical Sonography
@@ -2487,7 +1987,6 @@
   :skill_levels:
     9:
       :code: 4T090
-      :title: Superintendent
   :shredouts: {}
 :4T0X1:
   :name: Medical Laboratory
@@ -2495,16 +1994,12 @@
   :skill_levels:
     1:
       :code: 4T011
-      :title: Helper
     3:
       :code: 4T031
-      :title: Apprentice
     5:
       :code: 4T051
-      :title: Journeyman
     7:
       :code: 4T071
-      :title: Craftsman
   :shredouts: {}
 :4T0X2:
   :name: Histopathology
@@ -2513,16 +2008,12 @@
   :skill_levels:
     1:
       :code: 4T012
-      :title: Helper
     3:
       :code: 4T032
-      :title: Apprentice
     5:
       :code: 4T052
-      :title: Journeyman
     7:
       :code: 4T072
-      :title: Craftsman
   :shredouts: {}
 :4V0X1:
   :name: Ophthalmic
@@ -2532,19 +2023,14 @@
   :skill_levels:
     1:
       :code: 4V011
-      :title: Helper
     3:
       :code: 4V031
-      :title: Apprentice
     5:
       :code: 4V051
-      :title: Journeyman
     7:
       :code: 4V071
-      :title: Craftsman
     9:
       :code: 4V091
-      :title: Superintendent
   :shredouts:
     :S: Ophthalmology
 :4Y0X0:
@@ -2554,7 +2040,6 @@
   :skill_levels:
     9:
       :code: 4Y090
-      :title: Superintendent
   :shredouts: {}
 :4Y0X1:
   :name: Dental Assistant
@@ -2562,16 +2047,12 @@
   :skill_levels:
     1:
       :code: 4Y011
-      :title: Helper
     3:
       :code: 4Y031
-      :title: Apprentice
     5:
       :code: 4Y051
-      :title: Journeyman
     7:
       :code: 4Y071
-      :title: Craftsman
   :shredouts:
     :H: Dental Hygienist
 :4Y0X2:
@@ -2581,16 +2062,12 @@
   :skill_levels:
     1:
       :code: 4Y012
-      :title: Helper
     3:
       :code: 4Y032
-      :title: Apprentice
     5:
       :code: 4Y052
-      :title: Journeyman
     7:
       :code: 4Y072
-      :title: Craftsman
   :shredouts: {}
 :5J0X1:
   :name: Paralegal
@@ -2600,19 +2077,14 @@
   :skill_levels:
     1:
       :code: 5J011
-      :title: Helper
     3:
       :code: 5J031
-      :title: Apprentice
     5:
       :code: 5J051
-      :title: Journeyman
     7:
       :code: 5J071
-      :title: Craftsman
     9:
       :code: 5J091
-      :title: Superintendent
   :shredouts: {}
 :5R0X1:
   :name: Religious Affairs
@@ -2622,19 +2094,14 @@
   :skill_levels:
     1:
       :code: 5R011
-      :title: Helper
     3:
       :code: 5R031
-      :title: Apprentice
     5:
       :code: 5R051
-      :title: Journeyman
     7:
       :code: 5R071
-      :title: Craftsman
     9:
       :code: 5R091
-      :title: Superintendent
   :shredouts: {}
 :6C0X1:
   :name: Contracting
@@ -2644,16 +2111,12 @@
   :skill_levels:
     1:
       :code: 6C011
-      :title: Helper
     3:
       :code: 6C031
-      :title: Apprentice
     5:
       :code: 6C051
-      :title: Journeyman
     7:
       :code: 6C071
-      :title: Craftsman
     9:
       :code: 6C091
       :title: Senior Enlisted Leader
@@ -2666,19 +2129,14 @@
   :skill_levels:
     1:
       :code: 6F011
-      :title: Helper
     3:
       :code: 6F031
-      :title: Apprentice
     5:
       :code: 6F051
-      :title: Journeyman
     7:
       :code: 6F071
-      :title: Craftsman
     9:
       :code: 6F091
-      :title: Superintendent
   :shredouts: {}
 :7S0X1:
   :name: Special Investigations
@@ -2688,16 +2146,13 @@
   :skill_levels:
     1:
       :code: 7S011
-      :title: Helper
     3:
       :code: 7S031
       :title: Journeyman
     7:
       :code: 7S071
-      :title: Craftsman
     9:
       :code: 7S091
-      :title: Superintendent
   :shredouts: {}
 :8G0X1:
   :name: Premier Honor Guard
@@ -2707,19 +2162,14 @@
   :skill_levels:
     1:
       :code: 8G011
-      :title: Helper
     3:
       :code: 8G031
-      :title: Apprentice
     5:
       :code: 8G051
-      :title: Journeyman
     7:
       :code: 8G071
-      :title: Craftsman
     9:
       :code: 8G091
-      :title: Superintendent
   :shredouts:
     :B: Pallbearer
     :C: Color Guard

--- a/lib/gov_codes/afsc/releases/dafocd/2025-10-31/officer.yml
+++ b/lib/gov_codes/afsc/releases/dafocd/2025-10-31/officer.yml
@@ -27,7 +27,6 @@
       :title: Aircraft Commander
     4:
       :code: 11B4
-      :title: Staff
   :shredouts:
     :A: B-1
     :B: B-2
@@ -51,7 +50,6 @@
       :title: Aircraft Commander
     4:
       :code: 11E4
-      :title: Staff
   :shredouts:
     :A: Airlift/Tanker/Bomber
     :B: Fighter
@@ -78,7 +76,6 @@
       :title: Flight Lead
     4:
       :code: 11F4
-      :title: Staff
   :shredouts:
     :B: A-10
     :F: F-15
@@ -99,10 +96,8 @@
   :qual_levels:
     3:
       :code: 11G3
-      :title: Qualified
     4:
       :code: 11G4
-      :title: Staff
   :shredouts: {}
 :11HX:
   :name: Rescue Pilot
@@ -120,7 +115,6 @@
       :title: Aircraft Commander
     4:
       :code: 11H4
-      :title: Staff
   :shredouts:
     :C: UH-1N
     :E: HH-60
@@ -143,7 +137,6 @@
       :title: Aircraft Commander
     4:
       :code: 11K4
-      :title: Staff
   :shredouts:
     :A: T-1
     :D: T-38
@@ -169,7 +162,6 @@
       :title: Aircraft Commander
     4:
       :code: 11M4
-      :title: Staff
   :shredouts:
     :A: C-5
     :B: C-130E/H
@@ -207,7 +199,6 @@
       :title: Aircraft Commander
     4:
       :code: 11R4
-      :title: Staff
   :shredouts:
     :A: E-3
     :B: E-4
@@ -238,7 +229,6 @@
       :title: Aircraft Commander
     4:
       :code: 11S4
-      :title: Staff
   :shredouts:
     :C: AC-130H
     :D: AC-130U
@@ -284,10 +274,8 @@
       :title: Entry/Student
     3:
       :code: 11U3
-      :title: Qualified
     4:
       :code: 11U4
-      :title: Staff
   :shredouts:
     :A: Operational Warfare Instructor
     :B: Squadron Operations/Operations Support
@@ -319,10 +307,8 @@
       :title: Intermediate
     3:
       :code: 12B3
-      :title: Qualified
     4:
       :code: 12B4
-      :title: Staff
   :shredouts:
     :C: B-1 WSO
     :D: B-52 EWO
@@ -342,10 +328,8 @@
       :title: Entry/Student
     3:
       :code: 12E3
-      :title: Qualified
     4:
       :code: 12E4
-      :title: Staff
   :shredouts:
     :A: Airlift/Tanker/Bomber
     :B: Fighter
@@ -365,10 +349,8 @@
       :title: Entry/Student
     3:
       :code: 12F3
-      :title: Qualified
     4:
       :code: 12F4
-      :title: Staff
   :shredouts:
     :F: F-15E WSO
     :G: F-15 EWO
@@ -385,10 +367,8 @@
   :qual_levels:
     3:
       :code: 12G3
-      :title: Qualified
     4:
       :code: 12G4
-      :title: Staff
   :shredouts:
     :W: EWO
 :12HX:
@@ -401,10 +381,8 @@
       :title: Entry/Student
     3:
       :code: 12H3
-      :title: Qualified
     4:
       :code: 12H4
-      :title: Staff
   :shredouts:
     :J: HC-130J
     :P: HC-130
@@ -420,10 +398,8 @@
       :title: Entry/Student
     3:
       :code: 12K3
-      :title: Qualified
     4:
       :code: 12K4
-      :title: Staff
   :shredouts:
     :Q: T-7
     :Y: General
@@ -438,10 +414,8 @@
       :title: Entry/Student
     3:
       :code: 12M3
-      :title: Qualified
     4:
       :code: 12M4
-      :title: Staff
   :shredouts:
     :B: C-130E/H
     :E: VC-25
@@ -461,10 +435,8 @@
       :title: Entry/Student
     3:
       :code: 12R3
-      :title: Qualified
     4:
       :code: 12R4
-      :title: Staff
   :shredouts:
     :A: E-3
     :B: E-4
@@ -489,10 +461,8 @@
       :title: Entry/Student
     3:
       :code: 12S3
-      :title: Qualified
     4:
       :code: 12S4
-      :title: Staff
   :shredouts:
     :A: AC-130H EWO
     :B: AC-130H FCO
@@ -526,10 +496,8 @@
       :title: Entry/Student
     3:
       :code: 12U3
-      :title: Qualified
     4:
       :code: 12U4
-      :title: Staff
   :shredouts:
     :A: MQ-1
     :B: MQ-9
@@ -550,10 +518,8 @@
       :title: Entry
     3:
       :code: 13A3
-      :title: Qualified
     4:
       :code: 13A4
-      :title: Staff
   :shredouts: {}
 :13BX:
   :name: Air Battle Manager
@@ -565,10 +531,8 @@
       :title: Entry
     3:
       :code: 13B3
-      :title: Qualified
     4:
       :code: 13B4
-      :title: Staff
   :shredouts:
     :B: AWACS
     :C: Fixed BMC2
@@ -592,10 +556,8 @@
       :title: Entry
     3:
       :code: 13H3
-      :title: Qualified
     4:
       :code: 13H4
-      :title: Staff
   :shredouts: {}
 :13MX:
   :name: Airfield Operations
@@ -607,10 +569,8 @@
       :title: Entry
     3:
       :code: 13M3
-      :title: Qualified
     4:
       :code: 13M4
-      :title: Staff
   :shredouts: {}
 :13NX:
   :name: Nuclear and Missile Operations
@@ -625,10 +585,8 @@
       :title: Intermediate
     3:
       :code: 13N3
-      :title: Qualified
     4:
       :code: 13N4
-      :title: Staff
   :shredouts: {}
 :13OX:
   :name: Multi-Domain Warfare Officer
@@ -640,10 +598,8 @@
       :title: Entry Level
     3:
       :code: 13O3
-      :title: Qualified
     4:
       :code: 13O4
-      :title: Staff
   :shredouts: {}
 :13SX:
   :name: Space Operations
@@ -655,10 +611,8 @@
       :title: Entry
     3:
       :code: 13S3
-      :title: Qualified
     4:
       :code: 13S4
-      :title: Staff
   :shredouts:
     :A: Orbital Warfare
     :B: Space Electronic Warfare
@@ -674,10 +628,8 @@
       :title: Entry Level
     3:
       :code: 13Z3
-      :title: Qualified
     4:
       :code: 13Z4
-      :title: Staff
   :shredouts: {}
 :14FX:
   :name: Information Operations
@@ -689,10 +641,8 @@
       :title: Entry
     3:
       :code: 14F3
-      :title: Qualified
     4:
       :code: 14F4
-      :title: Staff
   :shredouts: {}
 :14NX:
   :name: Intelligence
@@ -704,10 +654,8 @@
       :title: Entry
     3:
       :code: 14N3
-      :title: Qualified
     4:
       :code: 14N4
-      :title: Staff
   :shredouts: {}
 :15AX:
   :name: Operations Analysis Officer
@@ -719,10 +667,8 @@
       :title: Entry
     3:
       :code: 15A3
-      :title: Qualified
     4:
       :code: 15A4
-      :title: Staff
   :shredouts: {}
 :15WX:
   :name: Weather and Environmental Sciences
@@ -734,10 +680,8 @@
       :title: Entry
     3:
       :code: 15W3
-      :title: Qualified
     4:
       :code: 15W4
-      :title: Staff
   :shredouts:
     :A: Advanced Weather Activities
 :16FX:
@@ -751,10 +695,8 @@
       :title: Entry
     3:
       :code: 16F3
-      :title: Qualified
     4:
       :code: 16F4
-      :title: Staff
   :shredouts:
     :C: SOUTHCOM
     :D: INDOPACOM
@@ -772,10 +714,8 @@
       :title: Entry
     3:
       :code: 16G3
-      :title: Qualified
     4:
       :code: 16G4
-      :title: Staff
   :shredouts: {}
 :16KX:
   :name: Software Development Officer (SDO)
@@ -788,10 +728,8 @@
       :title: Entry
     3:
       :code: 16K3
-      :title: Qualified
     4:
       :code: 16K4
-      :title: Staff
   :shredouts:
     :D: Product Designer
     :E: Software Engineer
@@ -808,10 +746,8 @@
       :title: Entry
     3:
       :code: 16P3
-      :title: Qualified
     4:
       :code: 16P4
-      :title: Staff
   :shredouts: {}
 :16RX:
   :name: Planning and Programming
@@ -822,10 +758,8 @@
       :title: Entry
     3:
       :code: 16R3
-      :title: Qualified
     4:
       :code: 16R4
-      :title: Staff
   :shredouts: {}
 :16ZX:
   :name: Rated Foreign Area Officer (FAO)
@@ -838,10 +772,8 @@
       :title: Entry
     3:
       :code: 16Z3
-      :title: Qualified
     4:
       :code: 16Z4
-      :title: Staff
   :shredouts:
     :C: SOUTHCOM
     :D: INDOPACOM
@@ -859,10 +791,8 @@
       :title: Entry
     3:
       :code: 17D3
-      :title: Qualified
     4:
       :code: 17D4
-      :title: Staff
   :shredouts:
     :T: Technical Track
     :W: Warfighter Communications
@@ -876,10 +806,8 @@
       :title: Entry
     3:
       :code: 17S3
-      :title: Qualified
     4:
       :code: 17S4
-      :title: Staff
   :shredouts:
     :A: Offensive Cyberspace Operator
     :B: Defensive Cyberspace Operator
@@ -894,10 +822,8 @@
       :title: Entry
     3:
       :code: 17W3
-      :title: Qualified
     4:
       :code: 17W4
-      :title: Staff
   :shredouts:
     :C: Cybersecurity Specialist
     :D: Data Operations Specialist
@@ -912,10 +838,8 @@
       :title: Entry
     3:
       :code: 17Y3
-      :title: Qualified
     4:
       :code: 17Y4
-      :title: Staff
   :shredouts:
     :A: Cyber Warfare Analyst
     :C: Cyber Capability Developer
@@ -932,10 +856,8 @@
       :title: Entry/Student
     3:
       :code: 18A3
-      :title: Qualified
     4:
       :code: 18A4
-      :title: Staff
   :shredouts:
     :A: MQ-1
     :B: MQ-9
@@ -954,10 +876,8 @@
       :title: Entry/Student
     3:
       :code: 18E3
-      :title: Qualified
     4:
       :code: 18E4
-      :title: Staff
   :shredouts:
     :A: Attack
     :B: Reconnaissance
@@ -971,10 +891,8 @@
   :qual_levels:
     3:
       :code: 18G3
-      :title: Qualified
     4:
       :code: 18G4
-      :title: Staff
   :shredouts: {}
 :18RX:
   :name: Reconnaissance Remotely Piloted Aircraft Pilot
@@ -986,10 +904,8 @@
       :title: Entry/Student
     3:
       :code: 18R3
-      :title: Qualified
     4:
       :code: 18R4
-      :title: Staff
   :shredouts:
     :C: RQ-4
     :E: RQ-170
@@ -1006,10 +922,8 @@
       :title: Entry/Student
     3:
       :code: 18S3
-      :title: Qualified
     4:
       :code: 18S4
-      :title: Staff
   :shredouts:
     :A: MQ-1
     :B: MQ-9
@@ -1029,10 +943,8 @@
       :title: Intermediate
     3:
       :code: 19Z3
-      :title: Qualified
     4:
       :code: 19Z4
-      :title: Staff
   :shredouts:
     :A: Special Tactics Officer
     :B: Tactical Air Control Party Officer
@@ -1057,10 +969,8 @@
       :title: Entry
     3:
       :code: 21A3
-      :title: Qualified
     4:
       :code: 21A4
-      :title: Staff
   :shredouts: {}
 :21MX:
   :name: Munitions and Missile Maintenance
@@ -1072,10 +982,8 @@
       :title: Entry
     3:
       :code: 21M3
-      :title: Qualified
     4:
       :code: 21M4
-      :title: Staff
   :shredouts:
     :A: Conventional
     :I: ICBM
@@ -1090,10 +998,8 @@
       :title: Entry
     3:
       :code: 21R3
-      :title: Qualified
     4:
       :code: 21R4
-      :title: Staff
   :shredouts: {}
 :30C0:
   :name: Support Commander
@@ -1111,10 +1017,8 @@
       :title: Entry
     3:
       :code: 31P3
-      :title: Qualified
     4:
       :code: 31P4
-      :title: Staff
   :shredouts: {}
 :32EX:
   :name: Civil Engineer
@@ -1126,10 +1030,8 @@
       :title: Entry
     3:
       :code: 32E3
-      :title: Qualified
     4:
       :code: 32E4
-      :title: Staff
   :shredouts:
     :A: Architect/Architectural Engineer
     :C: Civil Engineer
@@ -1149,10 +1051,8 @@
       :title: Entry
     3:
       :code: 35B3
-      :title: Qualified
     4:
       :code: 35B4
-      :title: Staff
   :shredouts: {}
 :35PX:
   :name: Public Affairs
@@ -1164,10 +1064,8 @@
       :title: Entry
     3:
       :code: 35P3
-      :title: Qualified
     4:
       :code: 35P4
-      :title: Staff
   :shredouts: {}
 :38FX:
   :name: Force Support
@@ -1179,10 +1077,8 @@
       :title: Entry
     3:
       :code: 38F3
-      :title: Qualified
     4:
       :code: 38F4
-      :title: Staff
   :shredouts:
     :A: Analyst
     :Q: Section Commander
@@ -1202,10 +1098,8 @@
       :title: Entry
     3:
       :code: 41A3
-      :title: Qualified
     4:
       :code: 41A4
-      :title: Staff
   :shredouts: {}
 :42BX:
   :name: Physical Therapist
@@ -1217,10 +1111,8 @@
       :title: Entry
     3:
       :code: 42B3
-      :title: Qualified
     4:
       :code: 42B4
-      :title: Staff
   :shredouts: {}
 :42EX:
   :name: Optometrist
@@ -1232,10 +1124,8 @@
       :title: Entry
     3:
       :code: 42E3
-      :title: Qualified
     4:
       :code: 42E4
-      :title: Staff
   :shredouts: {}
 :42FX:
   :name: Podiatric Surgeon
@@ -1247,10 +1137,8 @@
       :title: Entry
     3:
       :code: 42F3
-      :title: Qualified
     4:
       :code: 42F4
-      :title: Staff
   :shredouts: {}
 :42GX:
   :name: Physician Assistant
@@ -1262,10 +1150,8 @@
       :title: Entry
     3:
       :code: 42G3
-      :title: Qualified
     4:
       :code: 42G4
-      :title: Staff
   :shredouts:
     :A: Orthopedics
     :B: Otolaryngology
@@ -1283,10 +1169,8 @@
       :title: Entry
     3:
       :code: 42N3
-      :title: Qualified
     4:
       :code: 42N4
-      :title: Staff
   :shredouts: {}
 :42PX:
   :name: Clinical Psychologist
@@ -1298,10 +1182,8 @@
       :title: Entry
     3:
       :code: 42P3
-      :title: Qualified
     4:
       :code: 42P4
-      :title: Staff
   :shredouts: {}
 :42SX:
   :name: Clinical Social Worker
@@ -1313,10 +1195,8 @@
       :title: Entry
     3:
       :code: 42S3
-      :title: Qualified
     4:
       :code: 42S4
-      :title: Staff
   :shredouts: {}
 :42TX:
   :name: Occupational Therapist
@@ -1328,10 +1208,8 @@
       :title: Entry
     3:
       :code: 42T3
-      :title: Qualified
     4:
       :code: 42T4
-      :title: Staff
   :shredouts: {}
 :43BX:
   :name: Biomedical Scientist
@@ -1340,10 +1218,8 @@
   :qual_levels:
     3:
       :code: 43B3
-      :title: Qualified
     4:
       :code: 43B4
-      :title: Staff
   :shredouts: {}
 :43DX:
   :name: Dietitian
@@ -1355,10 +1231,8 @@
       :title: Entry
     3:
       :code: 43D3
-      :title: Qualified
     4:
       :code: 43D4
-      :title: Staff
   :shredouts: {}
 :43EX:
   :name: Bioenvironmental Engineer
@@ -1370,10 +1244,8 @@
       :title: Entry
     3:
       :code: 43E3
-      :title: Qualified
     4:
       :code: 43E4
-      :title: Staff
   :shredouts: {}
 :43HX:
   :name: Public Health Officer
@@ -1385,10 +1257,8 @@
       :title: Entry
     3:
       :code: 43H3
-      :title: Qualified
     4:
       :code: 43H4
-      :title: Staff
   :shredouts: {}
 :43PX:
   :name: Pharmacist
@@ -1400,10 +1270,8 @@
       :title: Entry
     3:
       :code: 43P3
-      :title: Qualified
     4:
       :code: 43P4
-      :title: Staff
   :shredouts: {}
 :43TX:
   :name: Biomedical Laboratory
@@ -1415,7 +1283,6 @@
       :title: Entry
     3:
       :code: 43T3
-      :title: Qualified
   :shredouts: {}
 :44AX:
   :name: Chief of Medical Staff
@@ -1427,7 +1294,6 @@
       :title: Entry
     3:
       :code: 44A3
-      :title: Qualified
   :shredouts: {}
 :44BX:
   :name: Preventive Medicine Physician
@@ -1439,10 +1305,8 @@
       :title: Entry
     3:
       :code: 44B3
-      :title: Qualified
     4:
       :code: 44B4
-      :title: Staff
   :shredouts: {}
 :44DX:
   :name: Pathologist
@@ -1454,10 +1318,8 @@
       :title: Entry
     3:
       :code: 44D3
-      :title: Qualified
     4:
       :code: 44D4
-      :title: Staff
   :shredouts:
     :A: Hematology
     :B: Cytology
@@ -1477,10 +1339,8 @@
       :title: Entry
     3:
       :code: 44E3
-      :title: Qualified
     4:
       :code: 44E4
-      :title: Staff
   :shredouts:
     :E: Emergency Medicine Services Physician
     :T: Medical Toxicology
@@ -1495,10 +1355,8 @@
       :title: Entry
     3:
       :code: 44F3
-      :title: Qualified
     4:
       :code: 44F4
-      :title: Staff
   :shredouts:
     :A: Sports Medicine
     :B: Obstetrics
@@ -1513,10 +1371,8 @@
       :title: Entry
     3:
       :code: 44G3
-      :title: Qualified
     4:
       :code: 44G4
-      :title: Staff
   :shredouts: {}
 :44HX:
   :name: Nuclear Medicine Physician
@@ -1528,10 +1384,8 @@
       :title: Entry
     3:
       :code: 44H3
-      :title: Qualified
     4:
       :code: 44H4
-      :title: Staff
   :shredouts: {}
 :44JX:
   :name: Medical Geneticist and Genomicist
@@ -1543,10 +1397,8 @@
       :title: Entry
     3:
       :code: 44J3
-      :title: Qualified
     4:
       :code: 44J4
-      :title: Staff
   :shredouts: {}
 :44KX:
   :name: Pediatrician
@@ -1558,10 +1410,8 @@
       :title: Entry
     3:
       :code: 44K3
-      :title: Qualified
     4:
       :code: 44K4
-      :title: Staff
   :shredouts:
     :A: Adolescent Medicine
     :B: Cardiology
@@ -1586,10 +1436,8 @@
       :title: Entry
     3:
       :code: 44M3
-      :title: Qualified
     4:
       :code: 44M4
-      :title: Staff
   :shredouts: {}
 :44NX:
   :name: Neurologist
@@ -1601,10 +1449,8 @@
       :title: Entry
     3:
       :code: 44N3
-      :title: Qualified
     4:
       :code: 44N4
-      :title: Staff
   :shredouts:
     :A: Sleep Medicine
     :B: Pain Management
@@ -1615,10 +1461,8 @@
   :qual_levels:
     3:
       :code: 44O3
-      :title: Qualified
     4:
       :code: 44O4
-      :title: Staff
   :shredouts: {}
 :44PX:
   :name: Psychiatrist
@@ -1630,10 +1474,8 @@
       :title: Entry
     3:
       :code: 44P3
-      :title: Qualified
     4:
       :code: 44P4
-      :title: Staff
   :shredouts:
     :A: Child Psychiatry
     :B: Forensic Psychiatry
@@ -1651,10 +1493,8 @@
       :title: Entry
     3:
       :code: 44R3
-      :title: Qualified
     4:
       :code: 44R4
-      :title: Staff
   :shredouts:
     :A: Neuroradiology
     :B: Special Procedures
@@ -1676,10 +1516,8 @@
       :title: Entry
     3:
       :code: 44S3
-      :title: Qualified
     4:
       :code: 44S4
-      :title: Staff
   :shredouts:
     :A: Dermatologic Surgery
     :B: Dermatopathology
@@ -1694,10 +1532,8 @@
       :title: Entry
     3:
       :code: 44T3
-      :title: Qualified
     4:
       :code: 44T4
-      :title: Staff
   :shredouts: {}
 :44UX:
   :name: Occupational Medicine Physician
@@ -1709,10 +1545,8 @@
       :title: Entry
     3:
       :code: 44U3
-      :title: Qualified
     4:
       :code: 44U4
-      :title: Staff
   :shredouts: {}
 :44YX:
   :name: Critical Care Medicine Physician
@@ -1724,10 +1558,8 @@
       :title: Entry
     3:
       :code: 44Y3
-      :title: Qualified
     4:
       :code: 44Y4
-      :title: Staff
   :shredouts:
     :A: Anesthesia
     :E: Emergency Medicine
@@ -1745,10 +1577,8 @@
       :title: Entry
     3:
       :code: 44Z3
-      :title: Qualified
     4:
       :code: 44Z4
-      :title: Staff
   :shredouts: {}
 :45AX:
   :name: Anesthesiologist
@@ -1760,10 +1590,8 @@
       :title: Entry
     3:
       :code: 45A3
-      :title: Qualified
     4:
       :code: 45A4
-      :title: Staff
   :shredouts:
     :A: Cardiothoracic
     :B: Pain Management
@@ -1777,10 +1605,8 @@
       :title: Entry
     3:
       :code: 45B3
-      :title: Qualified
     4:
       :code: 45B4
-      :title: Staff
   :shredouts:
     :A: Hand Surgery
     :B: Pediatrics
@@ -1800,10 +1626,8 @@
       :title: Entry
     3:
       :code: 45E3
-      :title: Qualified
     4:
       :code: 45E4
-      :title: Staff
   :shredouts:
     :A: Oculoplastics
     :B: Comea/External Disease
@@ -1822,10 +1646,8 @@
       :title: Entry
     3:
       :code: 45G3
-      :title: Qualified
     4:
       :code: 45G4
-      :title: Staff
   :shredouts:
     :A: Endocrinology
     :B: Oncology
@@ -1844,10 +1666,8 @@
       :title: Entry
     3:
       :code: 45N3
-      :title: Qualified
     4:
       :code: 45N4
-      :title: Staff
   :shredouts:
     :A: Otology/Neurotology
     :C: Pediatric Otolaryngology
@@ -1864,10 +1684,8 @@
       :title: Entry
     3:
       :code: 45P3
-      :title: Qualified
     4:
       :code: 45P4
-      :title: Staff
   :shredouts: {}
 :45SX:
   :name: Surgeon
@@ -1879,10 +1697,8 @@
       :title: Entry
     3:
       :code: 45S3
-      :title: Qualified
     4:
       :code: 45S4
-      :title: Staff
   :shredouts:
     :A: Thoracic
     :B: Colon and Rectal
@@ -1903,10 +1719,8 @@
       :title: Entry
     3:
       :code: 45U3
-      :title: Qualified
     4:
       :code: 45U4
-      :title: Staff
   :shredouts:
     :A: Pediatrics
     :B: Oncology
@@ -1919,10 +1733,8 @@
   :qual_levels:
     3:
       :code: 46A3
-      :title: Qualified
     4:
       :code: 46A4
-      :title: Staff
   :shredouts: {}
 :46FX:
   :name: Flight Nurse
@@ -1934,10 +1746,8 @@
       :title: Entry
     3:
       :code: 46F3
-      :title: Qualified
     4:
       :code: 46F4
-      :title: Staff
   :shredouts: {}
 :46NX:
   :name: Clinical Nurse
@@ -1949,10 +1759,8 @@
       :title: Entry
     3:
       :code: 46N3
-      :title: Qualified
     4:
       :code: 46N4
-      :title: Staff
   :shredouts: {}
 :46PX:
   :name: Mental Health Nurse
@@ -1964,10 +1772,8 @@
       :title: Entry
     3:
       :code: 46P3
-      :title: Qualified
     4:
       :code: 46P4
-      :title: Staff
   :shredouts: {}
 :46SX:
   :name: Operating Room Nurse
@@ -1979,10 +1785,8 @@
       :title: Entry
     3:
       :code: 46S3
-      :title: Qualified
     4:
       :code: 46S4
-      :title: Staff
   :shredouts: {}
 :46YX:
   :name: Advanced Practice Registered Nurse (APRN)
@@ -1995,10 +1799,8 @@
       :title: Entry
     3:
       :code: 46Y3
-      :title: Qualified
     4:
       :code: 46Y4
-      :title: Staff
   :shredouts: {}
 :47BX:
   :name: Orthodontist
@@ -2010,10 +1812,8 @@
       :title: Entry
     3:
       :code: 47B3
-      :title: Qualified
     4:
       :code: 47B4
-      :title: Staff
   :shredouts: {}
 :47DX:
   :name: Oral and Maxillofacial Pathologist
@@ -2025,10 +1825,8 @@
       :title: Entry
     3:
       :code: 47D3
-      :title: Qualified
     4:
       :code: 47D4
-      :title: Staff
   :shredouts: {}
 :47EX:
   :name: Endodontist
@@ -2040,10 +1838,8 @@
       :title: Entry
     3:
       :code: 47E3
-      :title: Qualified
     4:
       :code: 47E4
-      :title: Staff
   :shredouts: {}
 :47GX:
   :name: Dentist
@@ -2055,10 +1851,8 @@
       :title: Entry
     3:
       :code: 47G3
-      :title: Qualified
     4:
       :code: 47G4
-      :title: Staff
   :shredouts:
     :A: Comprehensive
     :B: Advanced Clinical
@@ -2078,10 +1872,8 @@
       :title: Entry
     3:
       :code: 47H3
-      :title: Qualified
     4:
       :code: 47H4
-      :title: Staff
   :shredouts: {}
 :47KX:
   :name: Pediatric Dentist
@@ -2093,10 +1885,8 @@
       :title: Entry
     3:
       :code: 47K3
-      :title: Qualified
     4:
       :code: 47K4
-      :title: Staff
   :shredouts: {}
 :47PX:
   :name: Prosthodontist
@@ -2108,10 +1898,8 @@
       :title: Entry
     3:
       :code: 47P3
-      :title: Qualified
     4:
       :code: 47P4
-      :title: Staff
   :shredouts:
     :A: Maxillofacial Prosthetics
     :B: Area Dental Laboratory
@@ -2126,10 +1914,8 @@
       :title: Entry
     3:
       :code: 47S3
-      :title: Qualified
     4:
       :code: 47S4
-      :title: Staff
   :shredouts:
     :B: Facial Esthetics
 :48AX:
@@ -2142,10 +1928,8 @@
       :title: Entry
     3:
       :code: 48A3
-      :title: Qualified
     4:
       :code: 48A4
-      :title: Staff
   :shredouts:
     :X: Space Medical Operations Experienced
 :48GX:
@@ -2158,10 +1942,8 @@
       :title: Entry
     3:
       :code: 48G3
-      :title: Qualified
     4:
       :code: 48G4
-      :title: Staff
   :shredouts:
     :X: Space Medical Operations Experienced
 :48OX:
@@ -2174,10 +1956,8 @@
       :title: Entry
     3:
       :code: 48O3
-      :title: Qualified
     4:
       :code: 48O4
-      :title: Staff
   :shredouts: {}
 :48RX:
   :name: Residency Trained Flight Surgeon
@@ -2189,10 +1969,8 @@
       :title: Entry
     3:
       :code: 48R3
-      :title: Qualified
     4:
       :code: 48R4
-      :title: Staff
   :shredouts:
     :E: Board eligible in emergency medicine
     :F: Board eligible in family medicine
@@ -2209,10 +1987,8 @@
       :title: Entry
     3:
       :code: 48V3
-      :title: Qualified
     4:
       :code: 48V4
-      :title: Staff
   :shredouts: {}
 :51JX:
   :name: Judge Advocate
@@ -2224,10 +2000,8 @@
       :title: Entry
     3:
       :code: 51J3
-      :title: Qualified
     4:
       :code: 51J4
-      :title: Staff
   :shredouts: {}
 :52RX:
   :name: Chaplain
@@ -2239,10 +2013,8 @@
       :title: Entry
     3:
       :code: 52R3
-      :title: Qualified
     4:
       :code: 52R4
-      :title: Staff
   :shredouts: {}
 :60C0:
   :name: Senior Materiel Leader-Upper Echelon
@@ -2260,10 +2032,8 @@
       :title: Entry
     3:
       :code: 61C3
-      :title: Qualified
     4:
       :code: 61C4
-      :title: Staff
   :shredouts:
     :N: Nuclear
 :61DX:
@@ -2276,10 +2046,8 @@
       :title: Entry
     3:
       :code: 61D3
-      :title: Qualified
     4:
       :code: 61D4
-      :title: Staff
   :shredouts:
     :N: Nuclear
 :62EX:
@@ -2292,10 +2060,8 @@
       :title: Entry
     3:
       :code: 62E3
-      :title: Qualified
     4:
       :code: 62E4
-      :title: Staff
   :shredouts:
     :I: Systems/Industrial/Human Factors
 :62S0:
@@ -2314,10 +2080,8 @@
       :title: Entry
     3:
       :code: 63A3
-      :title: Qualified
     4:
       :code: 63A4
-      :title: Staff
   :shredouts: {}
 :63G0:
   :name: Senior Materiel Leader-Lower Echelon
@@ -2341,10 +2105,8 @@
       :title: Entry
     3:
       :code: 64P3
-      :title: Qualified
     4:
       :code: 64P4
-      :title: Staff
   :shredouts: {}
 :65FX:
   :name: Financial Management
@@ -2356,10 +2118,8 @@
       :title: Entry
     3:
       :code: 65F3
-      :title: Qualified
     4:
       :code: 65F4
-      :title: Staff
   :shredouts: {}
 :65WX:
   :name: Cost Analysis
@@ -2371,10 +2131,8 @@
       :title: Entry
     3:
       :code: 65W3
-      :title: Qualified
     4:
       :code: 65W4
-      :title: Staff
   :shredouts: {}
 :71SX:
   :name: Special Investigations
@@ -2386,8 +2144,6 @@
       :title: Entry
     3:
       :code: 71S3
-      :title: Qualified
     4:
       :code: 71S4
-      :title: Staff
   :shredouts: {}

--- a/test/gov_codes/afsc/enlisted_release_test.rb
+++ b/test/gov_codes/afsc/enlisted_release_test.rb
@@ -36,6 +36,8 @@ module GovCodes
               7:
                 :code: 1A172
                 :title: Craftsman
+              9:
+                :code: 1A192
             :shredouts:
               :A: C-5 Flight Engineer
               :Y: General
@@ -85,6 +87,12 @@ module GovCodes
 
       it "returns nil for a specialty absent from the release" do
         _(Enlisted.find("9Z9X9")).must_be_nil
+      end
+
+      it "falls back to the standard skill-level title when the release omits it" do
+        code = Enlisted.find("1A192")
+        _(code.skill_level_number).must_equal 9
+        _(code.skill_level_name).must_equal "Superintendent"
       end
 
       describe "search over the versioned index" do

--- a/test/gov_codes/afsc/officer_release_test.rb
+++ b/test/gov_codes/afsc/officer_release_test.rb
@@ -33,6 +33,14 @@ module GovCodes
         _(code.name).must_equal "Bomber Pilot"
       end
 
+      it "falls back to the standard qualification-level title when the release omits it" do
+        qualified = Officer.find("11G3")
+        _(qualified.qualification_level_name).must_equal "Qualified"
+
+        staff = Officer.find("11G4")
+        _(staff.qualification_level_name).must_equal "Staff"
+      end
+
       it "resolves a literal bare code" do
         code = Officer.find("10C0")
         _(code).wont_be_nil


### PR DESCRIPTION
## Summary

- Enlisted `skill_levels` and officer `qual_levels` repeated a `:title` for every ladder rung of every specialty, even though it's almost always a fixed function of the digit (enlisted 1/3/5/7/9 = Helper/Apprentice/Journeyman/Craftsman/Superintendent; officer 3/4 = Qualified/Staff). `:code` stays as extracted (it's the extractor's verified, verbatim-from-PDF ground truth).
- Only elide a level's title when one value covers the vast majority (>=90%): all enlisted levels qualify, but officer levels 1-2 reflect a real flying vs. non-flying doctrinal split with no dominant default, so those stay fully explicit.
- `Enlisted` already had a fallback for an omitted title, but its level-9 default was wrong ("Senior Enlisted Leader" instead of the actual majority, "Superintendent" — 84/88 real entries). `Officer` had no fallback at all and needed one added, or an elided title would have resolved to `nil`.
- The extractor (`bin/extract_afsc_from_pdf.rb`) now strips a rung's `:title` when it matches the runtime default, reusing the same `SKILL_LEVELS`/`QUAL_LEVELS` constants the lookup fallback uses (single source of truth, no duplicated map).
- Regenerated both `2025-10-31` release YAMLs from the source PDFs; the diff is title lines disappearing only where they match the new defaults — no `:code`/`:name`/`:shredouts` changes.